### PR TITLE
#32480 Fixed dependency versions.

### DIFF
--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,11 +11,13 @@
     
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.103-preview</PostSharpEngineeringVersion>
-		<MetalamaVersion>branch:master</MetalamaVersion>
-        <MetalamaVersion Condition="$(VcsBranch.StartsWith('master'))">0.5.79-preview</MetalamaVersion>
+        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
+		<!-- Public version -->
+		<MetalamaVersion>0.5.79-preview</MetalamaVersion>
+		<!-- Development version -->
+        <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
 
-		<MetalamaOpenVirtuosityVersion>0.5.31-preview</MetalamaOpenVirtuosityVersion>
+		<MetalamaOpenVirtuosityVersion>0.5.36-preview</MetalamaOpenVirtuosityVersion>
 
 		<MicrosoftNETTestSdkVersion>17.0.0</MicrosoftNETTestSdkVersion>
 		<NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>

--- a/eng/Versions.props
+++ b/eng/Versions.props
@@ -11,16 +11,16 @@
     
     <!-- Set the default versions of dependencies -->
     <PropertyGroup>
-        <PostSharpEngineeringVersion>1.0.113-preview</PostSharpEngineeringVersion>
-		    <!-- Public version -->
-		    <MetalamaVersion>0.5.80-preview</MetalamaVersion>
-		    <!-- Development version -->
-        <MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
+        <PostSharpEngineeringVersion>1.0.114-preview</PostSharpEngineeringVersion>
+		<!-- Public version -->
+		<MetalamaVersion>0.5.80-preview</MetalamaVersion>
+		<!-- Development version -->
+		<MetalamaVersion Condition="$(VcsBranch)!=''">branch:master</MetalamaVersion>
 
-		    <MetalamaOpenVirtuosityVersion>0.5.36-preview</MetalamaOpenVirtuosityVersion>
+		<MetalamaOpenVirtuosityVersion>0.5.36-preview</MetalamaOpenVirtuosityVersion>
 
-		    <MicrosoftNETTestSdkVersion>17.0.0</MicrosoftNETTestSdkVersion>
-		    <NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
+		<MicrosoftNETTestSdkVersion>17.0.0</MicrosoftNETTestSdkVersion>
+		<NewtonsoftJsonVersion>13.0.1</NewtonsoftJsonVersion>
         <SoothsilverRandomVersion>1.1.0</SoothsilverRandomVersion>
         <xUnitVersion>2.4.1</xUnitVersion>
     </PropertyGroup>

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.113-preview"
+    "PostSharp.Engineering.Sdk": "1.0.114-preview"
   }
 }

--- a/global.json
+++ b/global.json
@@ -4,6 +4,6 @@
     "rollForward": "disable"
   },
   "msbuild-sdks": {
-    "PostSharp.Engineering.Sdk": "1.0.103-preview"
+    "PostSharp.Engineering.Sdk": "1.0.113-preview"
   }
 }


### PR DESCRIPTION
Changes:
* Changed dependencies versions to build with `dotnet build` correctly.
* Updated Engineering for Merge Publisher change.