### PR TITLE
Fix VirtuosityWeaver crash on C# 14 extension blocks (#94)

### DIFF
--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.cs
@@ -1,0 +1,32 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, VSTHRD100
+
+using System.Threading.Tasks;
+
+#pragma warning disable CA1822 // Mark members as static
+
+namespace Metalama.Community.Virtuosity.TestApp
+{
+    // The weaver must not crash on C# 14 extension blocks. Members declared inside an
+    // extension block cannot be virtual, so they are not transformed (see issue #94).
+    [Virtualize]
+    internal static class ValueTaskExtensions
+    {
+        extension<T>(ValueTask<T> valueTask)
+        {
+            // Not transformed (extension members cannot be virtual).
+            public ValueTask ToValueTask()
+            {
+                if (valueTask.IsCompletedSuccessfully)
+                {
+                    valueTask.GetAwaiter().GetResult();
+
+                    return default;
+                }
+
+                return new ValueTask(valueTask.AsTask());
+            }
+        }
+    }
+}

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.cs
@@ -27,6 +27,17 @@ namespace Metalama.Community.Virtuosity.TestApp
 
                 return new ValueTask(valueTask.AsTask());
             }
+
+            // Not transformed (extension members cannot be virtual).
+            public bool IsDone => valueTask.IsCompleted;
         }
+    }
+
+    // A regular class is still virtualized normally even when the project contains extension blocks.
+    [Virtualize]
+    internal class RegularClass
+    {
+        // Transformed.
+        public void Public() { }
     }
 }

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.t.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.t.cs
@@ -19,6 +19,17 @@ namespace Metalama.Community.Virtuosity.TestApp
         }
         return new ValueTask(valueTask.AsTask());
       }
+      // Not transformed (extension members cannot be virtual).
+      public bool IsDone => valueTask.IsCompleted;
+    }
+  }
+  // A regular class is still virtualized normally even when the project contains extension blocks.
+  [Virtualize]
+  internal class RegularClass
+  {
+    // Transformed.
+    public virtual void Public()
+    {
     }
   }
 }

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.t.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/ExtensionBlock.t.cs
@@ -1,0 +1,24 @@
+using System.Threading.Tasks;
+#pragma warning disable CA1822 // Mark members as static
+namespace Metalama.Community.Virtuosity.TestApp
+{
+  // The weaver must not crash on C# 14 extension blocks. Members declared inside an
+  // extension block cannot be virtual, so they are not transformed (see issue #94).
+  [Virtualize]
+  internal static class ValueTaskExtensions
+  {
+    extension<T>(ValueTask<T> valueTask)
+    {
+      // Not transformed (extension members cannot be virtual).
+      public ValueTask ToValueTask()
+      {
+        if (valueTask.IsCompletedSuccessfully)
+        {
+          valueTask.GetAwaiter().GetResult();
+          return default;
+        }
+        return new ValueTask(valueTask.AsTask());
+      }
+    }
+  }
+}

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/Interface.t.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/Interface.t.cs
@@ -1,1 +1,1 @@
-// Error LAMA0037 on `Virtualize`: `The aspect 'Virtualize' cannot be applied to the type 'I' because 'I' must be class or a record class.`
+// Error LAMA0037 on `Virtualize`: `The aspect 'Virtualize' cannot be applied to the type 'I' because 'I' must be class.`

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/Metalama.Community.Virtuosity.UnitTests.csproj
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/Metalama.Community.Virtuosity.UnitTests.csproj
@@ -8,6 +8,8 @@
 
   <ItemGroup>
     <PackageReference Include="xunit.assert" />
+    <PackageReference Include="xunit" />
+    <PackageReference Include="xunit.runner.visualstudio" />
     <ProjectReference Include="..\Metalama.Community.Virtuosity\Metalama.Community.Virtuosity.csproj" />
     <PackageReference Include="Metalama.Testing.AspectTesting" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/Struct.t.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/Struct.t.cs
@@ -1,1 +1,1 @@
-// Error LAMA0037 on `Virtualize`: `The aspect 'Virtualize' cannot be applied to the type 'S' because 'S' must be class or a record class.`
+// Error LAMA0037 on `Virtualize`: `The aspect 'Virtualize' cannot be applied to the type 'S' because 'S' must be class.`

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity/VirtuosityWeaver.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity/VirtuosityWeaver.cs
@@ -5,7 +5,6 @@ using Metalama.Framework.Engine.AspectWeavers;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using static Microsoft.CodeAnalysis.CSharp.SyntaxKind;
@@ -33,7 +32,13 @@ namespace Metalama.Community.Virtuosity
                     StructDeclarationSyntax => false,
                     RecordDeclarationSyntax record when record.ClassOrStructKeyword.IsKind( StructKeyword ) => false,
                     RecordDeclarationSyntax => true,
-                    _ => throw new ArgumentOutOfRangeException()
+
+                    // Members of any other declaration kind cannot be virtualized and must be left
+                    // unchanged. In particular, a C# 14 extension block (ExtensionBlockDeclarationSyntax)
+                    // is a MemberDeclarationSyntax that previously fell through here and crashed the
+                    // weaver with an ArgumentOutOfRangeException (#94). The type cannot be matched by
+                    // name because the weaver compiles against an older Roslyn that predates it.
+                    _ => false
                 };
 
             private static SyntaxTokenList ModifyModifiers( SyntaxTokenList modifiers, bool addVirtual = true )


### PR DESCRIPTION
Fixes metalama/Metalama.Community#94.

## Problem

`VirtuosityWeaver` crashes with `SyntaxProcessingException` / `ArgumentOutOfRangeException` when a project contains a C# 14 *extension block* (`extension<T>(...) { ... }`). When the weaver walks a `static class` containing an extension block, it calls `CanTransformType` with the `ExtensionBlockDeclarationSyntax` node (the parent of the members inside the block). That node is not handled by the type-kind `switch`, which falls through to `throw new ArgumentOutOfRangeException()`.

## Fix

`CanTransformType` now returns `false` for any unrecognized `MemberDeclarationSyntax` instead of throwing. Extension-block members cannot be `virtual`, so they are simply left unchanged. This is also robust against future Roslyn declaration kinds.

> Note: the node cannot be matched by name (`ExtensionBlockDeclarationSyntax => false`) as the issue suggested, because the weaver compiles against Roslyn 4.12 — which predates extension blocks — while running against a newer Roslyn. The `_ => false` default is the version-independent equivalent.

## Regression test

`ExtensionBlock.cs` applies `[Virtualize]` to a `static class` with an extension block containing a method and a property, plus a regular class. It verifies:
- extension members are **not** virtualized (and the weaver no longer crashes);
- a regular class is **still** virtualized normally even when the project contains extension blocks.

## Test infrastructure note

`Metalama.Community.Virtuosity.UnitTests` was missing the `xunit` / `xunit.runner.visualstudio` references, so its snapshot tests were never discovered/executed by VSTest (unlike the canonical Metalama aspect-test projects). I added them. Activating the dormant tests surfaced two **pre-existing** stale `LAMA0037` baselines (`must be class or a record class` → current `must be class`), which I refreshed. All 6 tests now run and pass under `Build.ps1 test`.

## Out of scope

The issue's secondary observation — `INamedType.IsStatic` returning `false` for a `static class` whose members live entirely inside extension blocks — is a core Metalama (not Community) concern and is left for separate investigation. The reported crash is fully resolved regardless of that behavior.

## Checklist

- [x] Phase 1 — Understand the issue
- [x] Phase 2 — Reproduce with a failing regression test
- [x] Phase 3 — Implement the fix
- [x] Phase 4 — `Build.ps1 build` + `Build.ps1 test` (zero warnings, all tests pass)
- [x] Phase 5 — Finalize (mark ready, request review)

— Claude for @PostSharpAgent