### PR TITLE
Fix [Virtualize] adding virtual to abstract members (#98)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -57,7 +57,7 @@ Notes when a full build does happen:
 1. Read all details about the issue online.
 2. Check conceptual documentation under `../Metalama.Documentation/content`, plus the aspect's own `README.md` and `Details.md` — user-visible behavior changes usually belong there.
 3. Create a branch: `topic/YYYY.N/XXXX-short-description` (merge target is always `develop/YYYY.N`, never the release branch).
-4. Mark the issue status **In Progress** and make sure it is assigned to me.
+4. Mark the issue status **In Progress** and make sure it is assigned to the current user.
 5. Track progress in a `<issue-number>-TODO.md` file. **Do not commit `*-TODO.md`.**
 6. Create issues promptly when discovering bugs during development.
 
@@ -67,7 +67,7 @@ Follow the `/eng:create-pr` skill. One addition it omits: GitHub only creates th
 
 ## Conventions
 
-- **Never sign commits.** GitHub comments, issues, and PRs are signed `— Claude for @gfraiteur` — no ad link.
+- **Never sign commits.** GitHub comments, issues, and PRs are signed `— Claude for <user-name>` — no ad link.
 - In tests, never use hardcoded delays; use barriers, `TaskCompletionSource`, or sync points.
 - Never `await` without a cancellation token — ever.
 - Don't lose time on cosmetic warnings (such as redundant usings) until the finalizing stage of a commit.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,84 @@
+# Claude Instructions for Metalama.Community
+
+## Prerequisites
+
+Before starting work:
+
+1. **Check plugins**: Verify the `eng@postsharp-engineering` and `metalama-dev@postsharp-engineering` plugins from `PostSharp.Engineering.AISkills` are available and load their _skills_ now. If not, ask the user to install them — they contain essential git workflow, build system, and release management knowledge.
+
+   **IMPORTANT**: For git operations (commit, PR, merge) or when asked to "start working on issue X", ALWAYS read the `eng` skill first to get correct conventions. Don't attempt commits or PRs without consulting it.
+
+   For writing aspects and templates, use the `metalama` skill. For developing the aspects in this repo, use `metalama-dev`.
+
+2. **Check branch**: Before making any modifications, verify you're on a feature branch (`topic/YYYY.N/XXXX-description`). If on `develop/*` or `release/*`, propose creating/switching to a topic branch first.
+
+## Repository Layout
+
+This repo is a single product (`Metalama.Community`) with a **single solution**, `Metalama.Community.sln`. Each aspect lives under `src/`:
+
+- `Metalama.Community.AutoCancellationToken`: propagates `CancellationToken` through async calls
+- `Metalama.Community.Costura`: embeds dependencies into the assembly (Fody.Costura port)
+- `Metalama.Community.Virtuosity`: makes members `virtual` without the keyword
+
+Each aspect directory contains the aspect project, a `*.UnitTests`/`*.Tests` project, and usually a `*.Demo` or `*.TestApp`. `eng/src/Program.cs` defines the product (packages, SDK versions, public artifacts).
+
+**Related repos** (in `..`):
+- `Metalama`: the core framework this repo builds on
+- `PostSharp.Engineering`: build orchestration SDK
+- `Metalama.Documentation`: conceptual documentation
+
+## Building and Testing
+
+Because this is a **single solution**, `dotnet build` / `dotnet test` are normally sufficient — you rarely need `Build.ps1 build`. Per the `eng` skill, **never run `Build.ps1 build` yourself; ask the user.**
+
+Notes when a full build does happen:
+- `Build.ps1 build` does not build test projects, only packable ones.
+- `Build.ps1 test` implicitly does a clean rebuild, so do NOT chain it after `Build.ps1 build`. After a build, run test projects with `dotnet test <project> --no-build`.
+- MSBuild binlogs land under `artifacts/logs`.
+- After a failed build, run `Build.ps1 tools kill` to release file locks before retrying.
+
+## Aspect Tests
+
+`Metalama.Community.Virtuosity.UnitTests` and `Metalama.Community.AutoCancellationToken.UnitTests` are **snapshot aspect tests** using `Metalama.Testing.AspectTesting`. `Metalama.Community.Costura.Tests` is a classic xUnit project.
+
+- Each test is a `Foo.cs` (input) / `Foo.t.cs` (expected transformed output) pair. There is no `metalamaTests.json` and no runner class — tests are discovered from the `.cs` files compiled into the assembly.
+- Run them with `dotnet test` from the test project directory. Filter by the **bare file name**: `dotnet test --filter "AbstractClass"`.
+- On failure, the actual output is written to `obj/transformed/<tfm>/Foo.t.cs` and echoed in the test output. Update a baseline by copying that file over the expected `.t.cs`.
+- The `.t.cs` baseline is **not** a verbatim copy of the input: the copyright header and any `#pragma` preceding the `namespace` are stripped, and the code is reformatted (2-space indent, braces on their own lines).
+- Compilation errors in the transformed code appear as `// Error CSxxxx on ...` comments at the top of the actual output, and fail the test. This makes aspect tests a reliable way to reproduce a "generated code doesn't compile" bug **before** fixing it — commit the failing test first (see #94, #98).
+
+## Debugging Build Issues
+
+1. **Check troubleshooting files**: Look at `%TEMP%\Metalama\CompileTimeTroubleshooting\...\errors.txt` for actual errors.
+2. **Trace data flow**: For MSBuild issues, trace from `.csproj` → `.targets` → Engine code.
+
+## Working on GitHub Issues
+
+1. Read all details about the issue online.
+2. Check conceptual documentation under `../Metalama.Documentation/content`, plus the aspect's own `README.md` and `Details.md` — user-visible behavior changes usually belong there.
+3. Create a branch: `topic/YYYY.N/XXXX-short-description` (merge target is always `develop/YYYY.N`, never the release branch).
+4. Mark the issue status **In Progress** and make sure it is assigned to me.
+5. Track progress in a `<issue-number>-TODO.md` file. **Do not commit `*-TODO.md`.**
+6. Create issues promptly when discovering bugs during development.
+
+### Pull requests
+
+Follow the `/eng:create-pr` skill. One addition it omits: GitHub only creates the issue link if the body contains a **closing keyword** (`Fixes #98`), not a bare `#98` reference. Include the keyword *before* running the base-branch toggle workaround, then verify with `closingIssuesReferences`.
+
+## Conventions
+
+- **Never sign commits.** GitHub comments, issues, and PRs are signed `— Claude for @gfraiteur` — no ad link.
+- In tests, never use hardcoded delays; use barriers, `TaskCompletionSource`, or sync points.
+- Never `await` without a cancellation token — ever.
+- Don't lose time on cosmetic warnings (such as redundant usings) until the finalizing stage of a commit.
+- When adding a package reference, also add the `PackageVersion` to `Directory.Packages.props`.
+
+## Container Environment
+
+When running in a container (`DockerBuild.ps1 -Claude`), `gh` is not available, and `git push` / `git fetch` over the network do not work either. **All GitHub network operations (push, fetch from remote, gh API calls, etc.) MUST go through the host-approval MCP server (`mcp__host-approval__execute_command`).**
+
+**If the MCP server is unavailable** (e.g., disconnected, the deferred-tool reminder says it's gone): STOP. Tell the user MCP is unavailable and ask them to run the command from the host. **Do NOT fall back to direct `git push` / `gh` via Bash** — it will fail, and bypassing MCP violates the human-in-the-loop policy. Treat MCP-unavailability as a policy boundary, not a tool-selection problem.
+
+## Shell
+
+Two shells are available and they take **different syntax**. PowerShell here-strings (`@'...'@`) are a silent corruption hazard in the Bash tool: it accepts them as literal text, so a commit message ends up wrapped in stray `@` lines instead of failing loudly. Use a heredoc (`git commit -F - <<'EOF'`) in Bash, or the PowerShell tool for `@'...'@`. Read the message back (`git log -1 --format=%B`) when it matters.

--- a/src/Metalama.Community.Virtuosity/Details.md
+++ b/src/Metalama.Community.Virtuosity/Details.md
@@ -3,6 +3,7 @@
 The following members are excluded because they can't be virtual:
 * static members
 * private members
+* abstract members, which are already implicitly virtual
 * members in nested structs and interfaces
 
 ## Why is this useful

--- a/src/Metalama.Community.Virtuosity/Details.md
+++ b/src/Metalama.Community.Virtuosity/Details.md
@@ -1,8 +1,8 @@
 ## How Virtuosity works
 
-The following members are excluded because they can't be virtual:
-* static members
-* private members
+The following members are not virtualized:
+* static members. Since C# 11, `static virtual` members are possible in interfaces, but they serve a different use case, so they are not virtualized either.
+* private members, which can't be virtual
 * abstract members, which are already implicitly virtual
 * members in nested structs and interfaces
 

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/AbstractClass.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/AbstractClass.cs
@@ -1,0 +1,22 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable CA1822 // Mark members as static
+
+namespace Metalama.Community.Virtuosity.Tests.AbstractClass
+{
+    [Virtualize]
+    internal abstract class AbstractClass
+    {
+        // Not transformed (an abstract member is implicitly virtual and cannot be marked virtual).
+        public abstract void AbstractMethod();
+
+        // Not transformed.
+        protected abstract int AbstractProperty { get; }
+
+        // Transformed.
+        public void ConcreteMethod() { }
+
+        // Transformed.
+        public int ConcreteProperty { get; }
+    }
+}

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/AbstractClass.t.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity.UnitTests/AbstractClass.t.cs
@@ -1,0 +1,17 @@
+namespace Metalama.Community.Virtuosity.Tests.AbstractClass
+{
+  [Virtualize]
+  internal abstract class AbstractClass
+  {
+    // Not transformed (an abstract member is implicitly virtual and cannot be marked virtual).
+    public abstract void AbstractMethod();
+    // Not transformed.
+    protected abstract int AbstractProperty { get; }
+    // Transformed.
+    public virtual void ConcreteMethod()
+    {
+    }
+    // Transformed.
+    public virtual int ConcreteProperty { get; }
+  }
+}

--- a/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity/VirtuosityWeaver.cs
+++ b/src/Metalama.Community.Virtuosity/Metalama.Community.Virtuosity/VirtuosityWeaver.cs
@@ -18,8 +18,9 @@ namespace Metalama.Community.Virtuosity
 
         private sealed class Rewriter : CSharpSyntaxRewriter
         {
+            // An abstract member is implicitly virtual, so adding the virtual modifier to it is illegal (CS0503).
             private static readonly SyntaxKind[] _forbiddenModifiers =
-                [StaticKeyword, SealedKeyword, VirtualKeyword, OverrideKeyword];
+                [StaticKeyword, SealedKeyword, VirtualKeyword, OverrideKeyword, AbstractKeyword];
 
             private static readonly SyntaxKind[] _requiredModifiers =
                 [PublicKeyword, ProtectedKeyword, InternalKeyword];


### PR DESCRIPTION
## Summary

- `VirtuosityWeaver.Rewriter` added the `virtual` modifier to `abstract` members, producing the illegal combination `public abstract virtual void M();` and failing the build with CS0503. Any `[Virtualize]` on an abstract class with `public`/`protected`/`internal` abstract members was affected.
- Added `AbstractKeyword` to `_forbiddenModifiers`, since an abstract member is already implicitly virtual. Abstract members are now left untouched; concrete members are still virtualized.
- Class declarations are unaffected: `VisitClassDeclaration` passes `addVirtual: false` and never consults that list.
- Added the `AbstractClass` aspect test (abstract method, abstract property, concrete method, concrete property). The test was committed first in a failing state, reproducing both CS0503 errors, then fixed — matching the approach used for #94.
- Documented the exclusion in `Details.md`, which already lists the members excluded because they can't be virtual.

Not a breaking change: the previously emitted code never compiled.

## Also included

- `CLAUDE.md` (new): ports the critical and relevant conventions from the Metalama repo's `CLAUDE.md`, adapted to this repo. Unrelated to the fix, bundled here at the request of @gfraiteur.

## Issues Fixed

Fixes #98 - `[Virtualize]` on an abstract class breaks abstract members (CS0503)

— Claude for @gfraiteur