### PR TITLE
AutoCancellationToken: run the tests, add an overload instead of changing signatures, fix weaver crashes

### DIFF
--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AnonymousFunctions.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AnonymousFunctions.cs
@@ -1,0 +1,58 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822, VSTHRD101
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.AnonymousFunctions;
+
+// Only the static-suppression branch of the anonymous-function visitors was covered before. These exercise the
+// propagating branch, which is what the visitors exist for.
+[AutoCancellationToken]
+internal class AnonymousFunctions
+{
+    // The token is propagated into a non-static local function.
+    public static async Task LocalFunction( CancellationToken ct )
+    {
+        await Inner();
+
+        async Task Inner() => await Helper();
+    }
+
+    // The token is propagated into a non-static lambda.
+    public static async Task ParenthesizedLambda( CancellationToken ct )
+    {
+        Func<Task> f = async () => await Helper();
+        await f();
+    }
+
+    // The token is propagated into a non-static simple lambda.
+    public static async Task SimpleLambda( CancellationToken ct )
+    {
+        Func<int, Task> f = async _ => await Helper();
+        await f( 0 );
+    }
+
+    // The token is propagated into a non-static anonymous method.
+    public static async Task AnonymousMethod( CancellationToken ct )
+    {
+        Func<Task> f = async delegate { await Helper(); };
+        await f();
+    }
+
+    // Not propagated into a static lambda: it cannot capture the enclosing parameter.
+    public static async Task StaticLambda( CancellationToken ct )
+    {
+        Func<Task> f = static async () => await Helper();
+        await f();
+    }
+
+    // Not propagated into a static anonymous method, for the same reason.
+    public static async Task StaticAnonymousMethod( CancellationToken ct )
+    {
+        Func<Task> f = static async delegate { await Helper(); };
+        await f();
+    }
+
+    private static async Task Helper() => await Task.Yield();
+
+    private static async Task Helper( CancellationToken cancellationToken ) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AnonymousFunctions.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AnonymousFunctions.cs
@@ -1,6 +1,9 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822, VSTHRD101
+#pragma warning disable IDE0039 // Use local function - the lambdas are what this test exercises.
+#pragma warning disable IDE0051 // Remove unused private members - the token overload exists so that the
+                                // transformed code has something to bind to.
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.AnonymousFunctions;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AnonymousFunctions.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AnonymousFunctions.t.cs
@@ -1,0 +1,51 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.AnonymousFunctions;
+// Only the static-suppression branch of the anonymous-function visitors was covered before. These exercise the
+// propagating branch, which is what the visitors exist for.
+[AutoCancellationToken]
+internal class AnonymousFunctions
+{
+  // The token is propagated into a non-static local function.
+  public static async Task LocalFunction(CancellationToken ct)
+  {
+    await Inner();
+    async Task Inner() => await Helper(ct);
+  }
+  // The token is propagated into a non-static lambda.
+  public static async Task ParenthesizedLambda(CancellationToken ct)
+  {
+    Func<Task> f = async () => await Helper(ct);
+    await f();
+  }
+  // The token is propagated into a non-static simple lambda.
+  public static async Task SimpleLambda(CancellationToken ct)
+  {
+    Func<int, Task> f = async _ => await Helper(ct);
+    await f(0);
+  }
+  // The token is propagated into a non-static anonymous method.
+  public static async Task AnonymousMethod(CancellationToken ct)
+  {
+    Func<Task> f = async delegate
+    {
+      await Helper(ct);
+    };
+    await f();
+  }
+  // Not propagated into a static lambda: it cannot capture the enclosing parameter.
+  public static async Task StaticLambda(CancellationToken ct)
+  {
+    Func<Task> f = static async () => await Helper();
+    await f();
+  }
+  // Not propagated into a static anonymous method, for the same reason.
+  public static async Task StaticAnonymousMethod(CancellationToken ct)
+  {
+    Func<Task> f = static async delegate
+    {
+      await Helper();
+    };
+    await f();
+  }
+  private static async Task Helper() => await Task.Yield();
+  private static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AsyncIterator.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AsyncIterator.cs
@@ -1,0 +1,21 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+using System.Collections.Generic;
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.AsyncIterator;
+
+// An async iterator is transformed like any other async method, but the token is not wired up to the enumerator:
+// the added parameter carries no [EnumeratorCancellation], so a token passed to WithCancellation is unconsumed.
+// The compiler reports this as CS8425, which is captured in the baseline - so at least this limitation is visible.
+[AutoCancellationToken]
+internal class Iterator
+{
+    public async IAsyncEnumerable<int> StreamAsync()
+    {
+        await Task.Yield();
+
+        yield return 1;
+    }
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AsyncIterator.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AsyncIterator.cs
@@ -1,6 +1,8 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822
+#pragma warning disable IDE0005 // Using directive is unnecessary - ImplicitUsings already imports it, but the
+                                // baseline records the directive as written, so it is kept.
 
 using System.Collections.Generic;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AsyncIterator.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/AsyncIterator.t.cs
@@ -1,0 +1,16 @@
+// Warning CS8425 on `StreamAsync`: `Async-iterator 'Iterator.StreamAsync(CancellationToken)' has one or more parameters of type 'CancellationToken' but none of them is decorated with the 'EnumeratorCancellation' attribute, so the cancellation token parameter from the generated 'IAsyncEnumerable<>.GetAsyncEnumerator' will be unconsumed`
+using System.Collections.Generic;
+namespace Metalama.Community.AutoCancellationToken.UnitTests.AsyncIterator;
+// An async iterator is transformed like any other async method, but the token is not wired up to the enumerator:
+// the added parameter carries no [EnumeratorCancellation], so a token passed to WithCancellation is unconsumed.
+// The compiler reports this as CS8425, which is captured in the baseline - so at least this limitation is visible.
+[AutoCancellationToken]
+internal class Iterator
+{
+  public IAsyncEnumerable<int> StreamAsync() => StreamAsync(default);
+  public async IAsyncEnumerable<int> StreamAsync(System.Threading.CancellationToken cancellationToken)
+  {
+    await Task.Yield();
+    yield return 1;
+  }
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/BackwardCompatibility.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/BackwardCompatibility.cs
@@ -1,0 +1,33 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.BackwardCompatibility;
+
+// #81: the aspect must not change the signature of an existing method, because that breaks callers. The original
+// signature is kept as a forwarder and the token-taking method is added as a new overload.
+[AutoCancellationToken]
+internal class Service
+{
+    public async Task DoWorkAsync( int value ) => await Task.Yield();
+
+    // A generic method: the forwarder must pass the type arguments through.
+    public async Task DoGenericAsync<T>( T value ) => await Task.Yield();
+
+    // A method with no parameters at all.
+    public async Task DoNothingAsync() => await Task.Yield();
+}
+
+// This type is NOT annotated, so it stands in for code outside the aspect's reach - an existing caller. It must
+// still compile against the original signatures, which is the whole point of #81.
+internal class ExistingCaller
+{
+    public async Task CallAsync()
+    {
+        var service = new Service();
+
+        await service.DoWorkAsync( 1 );
+        await service.DoGenericAsync( "x" );
+        await service.DoNothingAsync();
+    }
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/BackwardCompatibility.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/BackwardCompatibility.t.cs
@@ -8,11 +8,9 @@ internal class Service
   public async Task DoWorkAsync(int value, System.Threading.CancellationToken cancellationToken) => await Task.Yield();
   // A generic method: the forwarder must pass the type arguments through.
   public Task DoGenericAsync<T>(T value) => DoGenericAsync<T>(value, default);
-  // A generic method: the forwarder must pass the type arguments through.
   public async Task DoGenericAsync<T>(T value, System.Threading.CancellationToken cancellationToken) => await Task.Yield();
   // A method with no parameters at all.
   public Task DoNothingAsync() => DoNothingAsync(default);
-  // A method with no parameters at all.
   public async Task DoNothingAsync(System.Threading.CancellationToken cancellationToken) => await Task.Yield();
 }
 // This type is NOT annotated, so it stands in for code outside the aspect's reach - an existing caller. It must

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/BackwardCompatibility.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/BackwardCompatibility.t.cs
@@ -1,0 +1,29 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.BackwardCompatibility;
+// #81: the aspect must not change the signature of an existing method, because that breaks callers. The original
+// signature is kept as a forwarder and the token-taking method is added as a new overload.
+[AutoCancellationToken]
+internal class Service
+{
+  public Task DoWorkAsync(int value) => DoWorkAsync(value, default);
+  public async Task DoWorkAsync(int value, System.Threading.CancellationToken cancellationToken) => await Task.Yield();
+  // A generic method: the forwarder must pass the type arguments through.
+  public Task DoGenericAsync<T>(T value) => DoGenericAsync<T>(value, default);
+  // A generic method: the forwarder must pass the type arguments through.
+  public async Task DoGenericAsync<T>(T value, System.Threading.CancellationToken cancellationToken) => await Task.Yield();
+  // A method with no parameters at all.
+  public Task DoNothingAsync() => DoNothingAsync(default);
+  // A method with no parameters at all.
+  public async Task DoNothingAsync(System.Threading.CancellationToken cancellationToken) => await Task.Yield();
+}
+// This type is NOT annotated, so it stands in for code outside the aspect's reach - an existing caller. It must
+// still compile against the original signatures, which is the whole point of #81.
+internal class ExistingCaller
+{
+  public async Task CallAsync()
+  {
+    var service = new Service();
+    await service.DoWorkAsync(1);
+    await service.DoGenericAsync("x");
+    await service.DoNothingAsync();
+  }
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.cs
@@ -1,0 +1,29 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.LocalNameCollision;
+
+[AutoCancellationToken]
+internal class LocalNameCollision
+{
+    // The added parameter must not collide with a local declared in the body (CS0136).
+    public async Task LocalVariable()
+    {
+        var cancellationToken = 0;
+        await Helper();
+        _ = cancellationToken;
+    }
+
+    // ... nor with a local function's name.
+    public async Task LocalFunctionName()
+    {
+        await Helper();
+        void cancellationToken() { }
+        cancellationToken();
+    }
+
+    private static async Task Helper() => await Task.Yield();
+
+    private static async Task Helper( CancellationToken cancellationToken ) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.cs
@@ -1,6 +1,8 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822
+#pragma warning disable IDE0051 // Remove unused private members - the token overload exists so that the
+                                // transformed code has something to bind to.
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.LocalNameCollision;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.t.cs
@@ -1,0 +1,23 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.LocalNameCollision;
+[AutoCancellationToken]
+internal class LocalNameCollision
+{
+  // The added parameter must not collide with a local declared in the body (CS0136).
+  public async Task LocalVariable(System.Threading.CancellationToken cancellationToken2 = default)
+  {
+    var cancellationToken = 0;
+    await Helper(cancellationToken2);
+    _ = cancellationToken;
+  }
+  // ... nor with a local function's name.
+  public async Task LocalFunctionName(System.Threading.CancellationToken cancellationToken2 = default)
+  {
+    await Helper(cancellationToken2);
+    void cancellationToken()
+    {
+    }
+    cancellationToken();
+  }
+  private static async Task Helper() => await Task.Yield();
+  private static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.t.cs
@@ -3,7 +3,7 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests.LocalNameCollision;
 internal class LocalNameCollision
 {
   // The added parameter must not collide with a local declared in the body (CS0136).
-  public Task LocalVariable() => LocalVariable(default); // The added parameter must not collide with a local declared in the body (CS0136).
+  public Task LocalVariable() => LocalVariable(default);
   public async Task LocalVariable(System.Threading.CancellationToken cancellationToken2)
   {
     var cancellationToken = 0;
@@ -12,7 +12,6 @@ internal class LocalNameCollision
   }
   // ... nor with a local function's name.
   public Task LocalFunctionName() => LocalFunctionName(default);
-  // ... nor with a local function's name.
   public async Task LocalFunctionName(System.Threading.CancellationToken cancellationToken2)
   {
     await Helper(cancellationToken2);

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/LocalNameCollision.t.cs
@@ -3,14 +3,17 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests.LocalNameCollision;
 internal class LocalNameCollision
 {
   // The added parameter must not collide with a local declared in the body (CS0136).
-  public async Task LocalVariable(System.Threading.CancellationToken cancellationToken2 = default)
+  public Task LocalVariable() => LocalVariable(default); // The added parameter must not collide with a local declared in the body (CS0136).
+  public async Task LocalVariable(System.Threading.CancellationToken cancellationToken2)
   {
     var cancellationToken = 0;
     await Helper(cancellationToken2);
     _ = cancellationToken;
   }
   // ... nor with a local function's name.
-  public async Task LocalFunctionName(System.Threading.CancellationToken cancellationToken2 = default)
+  public Task LocalFunctionName() => LocalFunctionName(default);
+  // ... nor with a local function's name.
+  public async Task LocalFunctionName(System.Threading.CancellationToken cancellationToken2)
   {
     await Helper(cancellationToken2);
     void cancellationToken()

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/Metalama.Community.AutoCancellationToken.UnitTests.csproj
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/Metalama.Community.AutoCancellationToken.UnitTests.csproj
@@ -8,6 +8,8 @@
 
     <ItemGroup>
         <PackageReference Include="xunit.assert" />
+        <PackageReference Include="xunit" />
+        <PackageReference Include="xunit.runner.visualstudio" />
         <ProjectReference Include="..\Metalama.Community.AutoCancellationToken\Metalama.Community.AutoCancellationToken.csproj" OutputItemType="Analyzer" />
         <PackageReference Include="Metalama.Testing.AspectTesting" />
         <PackageReference Include="Microsoft.NET.Test.Sdk" />

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/MyClass.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/MyClass.t.cs
@@ -2,110 +2,116 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests;
 [AutoCancellationToken]
 internal class MyClass
 {
-    public static async Task MakeRequests( CancellationToken ct )
+  public static async Task MakeRequests(CancellationToken ct)
+  {
+    using var client = new HttpClient();
+    // After transformation, the call to MakeRequest should include a CancellationToken.
+    await MakeRequest(client, ct);
+    Console.WriteLine("request 1 succeeded");
+    await MakeRequest(client, ct);
+    Console.WriteLine("request 2 succeeded");
+  }
+  public static async Task MakeRequests_MultipleCtParams(CancellationToken ct1, CancellationToken ct2)
+  {
+    using var client = new HttpClient();
+    // After transformation, the call to MakeRequest should *not* include a CancellationToken, because
+    // the containing method has two or more CancellationToken parameters.
+    await MakeRequest(client);
+    Console.WriteLine("request 1 succeeded");
+    await MakeRequest(client);
+    Console.WriteLine("request 2 succeeded");
+  }
+  public static async Task MakeRequests_StaticLocal(CancellationToken ct1)
+  {
+    await StaticLocalMakeRequest();
+    static async Task StaticLocalMakeRequest()
     {
-        using var client = new HttpClient();
-        // After transformation, the call to MakeRequest should include a CancellationToken.
-        await MakeRequest( client, ct );
-        Console.WriteLine( "request 1 succeeded" );
-        await MakeRequest( client, ct );
-        Console.WriteLine( "request 2 succeeded" );
+      using var client = new HttpClient();
+      // After transformation, the call to MakeRequest should *not* include a CancellationToken, because
+      // the containing method is a static local function (this is the documented behaviour).
+      await MakeRequest(client);
+      Console.WriteLine("request 1 succeeded");
+      await MakeRequest(client);
+      Console.WriteLine("request 2 succeeded");
     }
-    public static async Task MakeRequests_MultipleCtParams( CancellationToken ct1, CancellationToken ct2 )
-    {
-        using var client = new HttpClient();
-        // After transformation, the call to MakeRequest should *not* include a CancellationToken, because
-        // the containing method has two or more CancellationToken parameters.
-        await MakeRequest( client );
-        Console.WriteLine( "request 1 succeeded" );
-        await MakeRequest( client );
-        Console.WriteLine( "request 2 succeeded" );
-    }
-    public static async Task MakeRequests_StaticLocal( CancellationToken ct1 )
-    {
-        await StaticLocalMakeRequest();
-        static async Task StaticLocalMakeRequest()
-        {
-            using var client = new HttpClient();
-            // After transformation, the call to MakeRequest should *not* include a CancellationToken, because
-            // the containing method is a static local function (this is the documented behaviour).
-            await MakeRequest( client );
-            Console.WriteLine( "request 1 succeeded" );
-            await MakeRequest( client );
-            Console.WriteLine( "request 2 succeeded" );
-        }
-    }
-    // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
-    // should include this argument.
-    private static async Task MakeRequest( HttpClient client, System.Threading.CancellationToken cancellationToken = default )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5", cancellationToken );
-    }
-    public static async Task MakeRequests_FinalParamterIsParamsArray( CancellationToken ct )
-    {
-        using var client = new HttpClient();
-        // After transformation, the call to MakeRequest_FinalParamterIsParamsArray should *not* include a CancellationToken
-        // because the final parameter is params object[].
-        await MakeRequest_FinalParamterIsParamsArray( client );
-        Console.WriteLine( "request 1 succeeded" );
-        await MakeRequest_FinalParamterIsParamsArray( client );
-        Console.WriteLine( "request 2 succeeded" );
-    }
-    // This method should not be transformed because adding a parameter after the existing
-    // final params object[] parameter is not valid C#.
-    private static async Task MakeRequest_FinalParamterIsParamsArray( HttpClient client, params object[] args )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5" );
-    }
-    public static async Task MakeRequests_FinalParameterOfAvailableOverloadIsGeneric( CancellationToken ct )
-    {
-        using var client = new HttpClient();
-        // After transformation, the call to Helper1.MakeRequest_Generic should *not* include a CancellationToken
-        // because the final parameter of the available overload in class Helper1 is generic.
-        await Helper1.MakeRequest_Generic( client );
-        Console.WriteLine( "request 1 succeeded" );
-        await Helper1.MakeRequest_Generic( client );
-        Console.WriteLine( "request 2 succeeded" );
-    }
-    public static async Task MakeRequests_ExistingOverload( CancellationToken ct )
-    {
-        using var client = new HttpClient();
-        // After transformation, the call to Helper2.MakeRequest should include a CancellationToken
-        // because a compatible overload already exists in class Helper2.
-        await Helper2.MakeRequest( client, ct );
-        Console.WriteLine( "request 1 succeeded" );
-        await Helper2.MakeRequest( client, ct );
-        Console.WriteLine( "request 2 succeeded" );
-    }
-    // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
-    // should include this argument. The weaver must choose a name other than "cancellationToken" for the added parameter.
-    public static async Task MakeRequest_ParameterNameCollision( HttpClient client, int cancellationToken, System.Threading.CancellationToken cancellationToken2 = default )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5", cancellationToken2 );
-    }
+  }
+  // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
+  // should include this argument.
+  private static Task MakeRequest(HttpClient client) => MakeRequest(client, default);
+  // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
+  // should include this argument.
+  private static async Task MakeRequest(HttpClient client, System.Threading.CancellationToken cancellationToken)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5", cancellationToken);
+  }
+  public static async Task MakeRequests_FinalParamterIsParamsArray(CancellationToken ct)
+  {
+    using var client = new HttpClient();
+    // After transformation, the call to MakeRequest_FinalParamterIsParamsArray should *not* include a CancellationToken
+    // because the final parameter is params object[].
+    await MakeRequest_FinalParamterIsParamsArray(client);
+    Console.WriteLine("request 1 succeeded");
+    await MakeRequest_FinalParamterIsParamsArray(client);
+    Console.WriteLine("request 2 succeeded");
+  }
+  // This method should not be transformed because adding a parameter after the existing
+  // final params object[] parameter is not valid C#.
+  private static async Task MakeRequest_FinalParamterIsParamsArray(HttpClient client, params object[] args)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5");
+  }
+  public static async Task MakeRequests_FinalParameterOfAvailableOverloadIsGeneric(CancellationToken ct)
+  {
+    using var client = new HttpClient();
+    // After transformation, the call to Helper1.MakeRequest_Generic should *not* include a CancellationToken
+    // because the final parameter of the available overload in class Helper1 is generic.
+    await Helper1.MakeRequest_Generic(client);
+    Console.WriteLine("request 1 succeeded");
+    await Helper1.MakeRequest_Generic(client);
+    Console.WriteLine("request 2 succeeded");
+  }
+  public static async Task MakeRequests_ExistingOverload(CancellationToken ct)
+  {
+    using var client = new HttpClient();
+    // After transformation, the call to Helper2.MakeRequest should include a CancellationToken
+    // because a compatible overload already exists in class Helper2.
+    await Helper2.MakeRequest(client, ct);
+    Console.WriteLine("request 1 succeeded");
+    await Helper2.MakeRequest(client, ct);
+    Console.WriteLine("request 2 succeeded");
+  }
+  // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
+  // should include this argument. The weaver must choose a name other than "cancellationToken" for the added parameter.
+  public static Task MakeRequest_ParameterNameCollision(HttpClient client, int cancellationToken) => MakeRequest_ParameterNameCollision(client, cancellationToken, default);
+  // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
+  // should include this argument. The weaver must choose a name other than "cancellationToken" for the added parameter.
+  public static async Task MakeRequest_ParameterNameCollision(HttpClient client, int cancellationToken, System.Threading.CancellationToken cancellationToken2)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5", cancellationToken2);
+  }
 }
 #pragma warning disable SA1402 // FileMayOnlyContainASingleType
 // Not transformed
 internal static class Helper1
 {
-    public static async Task MakeRequest_Generic( HttpClient client )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5" );
-    }
-    public static async Task MakeRequest_Generic<T>( HttpClient client, T arg )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5" );
-    }
+  public static async Task MakeRequest_Generic(HttpClient client)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5");
+  }
+  public static async Task MakeRequest_Generic<T>(HttpClient client, T arg)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5");
+  }
 }
 // Not transformed
 internal static class Helper2
 {
-    public static async Task MakeRequest( HttpClient client )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5" );
-    }
-    public static async Task MakeRequest( HttpClient client, CancellationToken ct )
-    {
-        await client.GetAsync( "https://httpbin.org/delay/5", ct );
-    }
+  public static async Task MakeRequest(HttpClient client)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5");
+  }
+  public static async Task MakeRequest(HttpClient client, CancellationToken ct)
+  {
+    await client.GetAsync("https://httpbin.org/delay/5", ct);
+  }
 }

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/MyClass.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/MyClass.t.cs
@@ -38,8 +38,6 @@ internal class MyClass
   // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
   // should include this argument.
   private static Task MakeRequest(HttpClient client) => MakeRequest(client, default);
-  // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
-  // should include this argument.
   private static async Task MakeRequest(HttpClient client, System.Threading.CancellationToken cancellationToken)
   {
     await client.GetAsync("https://httpbin.org/delay/5", cancellationToken);
@@ -83,8 +81,6 @@ internal class MyClass
   // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
   // should include this argument. The weaver must choose a name other than "cancellationToken" for the added parameter.
   public static Task MakeRequest_ParameterNameCollision(HttpClient client, int cancellationToken) => MakeRequest_ParameterNameCollision(client, cancellationToken, default);
-  // After transformation, MakeRequest should contain a CancellationToken parameter, and the call to client.GetAsync
-  // should include this argument. The weaver must choose a name other than "cancellationToken" for the added parameter.
   public static async Task MakeRequest_ParameterNameCollision(HttpClient client, int cancellationToken, System.Threading.CancellationToken cancellationToken2)
   {
     await client.GetAsync("https://httpbin.org/delay/5", cancellationToken2);

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.cs
@@ -4,9 +4,8 @@
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.NestedTypes;
 
-// This test pins CURRENT behaviour, which is known to be wrong for nested types: the aspect is silently ignored on
-// a nested type even when the nested type carries the attribute itself. See the linked issue. The baseline below
-// will change when that is fixed, which is the point of pinning it here.
+// The aspect used to be silently ignored on nested types (#109), because the rewriters returned early for a type
+// without the annotation and so never reached a nested type that carried it.
 [AutoCancellationToken]
 internal class Outer
 {
@@ -19,7 +18,7 @@ internal class Outer
         public async Task NestedAsync() => await Helper();
     }
 
-    // Not transformed, although it should be: the aspect is silently ignored on nested types.
+    // Transformed: a nested type that carries the attribute is now handled (#109).
     [AutoCancellationToken]
     internal class NestedAnnotated
     {

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.cs
@@ -1,6 +1,8 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822
+#pragma warning disable IDE0051 // Remove unused private members - the token overload exists so that the
+                                // transformed code has something to bind to.
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.NestedTypes;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.cs
@@ -1,0 +1,32 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.NestedTypes;
+
+// This test pins CURRENT behaviour, which is known to be wrong for nested types: the aspect is silently ignored on
+// a nested type even when the nested type carries the attribute itself. See the linked issue. The baseline below
+// will change when that is fixed, which is the point of pinning it here.
+[AutoCancellationToken]
+internal class Outer
+{
+    // Transformed.
+    public async Task OuterAsync() => await Helper();
+
+    // Not transformed, as expected: the attribute applies to the members of the type it is applied to.
+    internal class NestedNotAnnotated
+    {
+        public async Task NestedAsync() => await Helper();
+    }
+
+    // Not transformed, although it should be: the aspect is silently ignored on nested types.
+    [AutoCancellationToken]
+    internal class NestedAnnotated
+    {
+        public async Task NestedAsync() => await Helper();
+    }
+
+    private static async Task Helper() => await Task.Yield();
+
+    private static async Task Helper( CancellationToken cancellationToken ) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.t.cs
@@ -5,7 +5,7 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests.NestedTypes;
 internal class Outer
 {
   // Transformed.
-  public Task OuterAsync() => OuterAsync(default); // Transformed.
+  public Task OuterAsync() => OuterAsync(default);
   public async Task OuterAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
   // Not transformed, as expected: the attribute applies to the members of the type it is applied to.
   internal class NestedNotAnnotated

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.t.cs
@@ -1,22 +1,23 @@
 namespace Metalama.Community.AutoCancellationToken.UnitTests.NestedTypes;
-// This test pins CURRENT behaviour, which is known to be wrong for nested types: the aspect is silently ignored on
-// a nested type even when the nested type carries the attribute itself. See the linked issue. The baseline below
-// will change when that is fixed, which is the point of pinning it here.
+// The aspect used to be silently ignored on nested types (#109), because the rewriters returned early for a type
+// without the annotation and so never reached a nested type that carried it.
 [AutoCancellationToken]
 internal class Outer
 {
   // Transformed.
-  public async Task OuterAsync(System.Threading.CancellationToken cancellationToken = default) => await Helper(cancellationToken);
+  public Task OuterAsync() => OuterAsync(default); // Transformed.
+  public async Task OuterAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
   // Not transformed, as expected: the attribute applies to the members of the type it is applied to.
   internal class NestedNotAnnotated
   {
     public async Task NestedAsync() => await Helper();
   }
-  // Not transformed, although it should be: the aspect is silently ignored on nested types.
+  // Transformed: a nested type that carries the attribute is now handled (#109).
   [AutoCancellationToken]
   internal class NestedAnnotated
   {
-    public async Task NestedAsync() => await Helper();
+    public Task NestedAsync() => NestedAsync(default);
+    public async Task NestedAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
   }
   private static async Task Helper() => await Task.Yield();
   private static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NestedTypes.t.cs
@@ -1,0 +1,23 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.NestedTypes;
+// This test pins CURRENT behaviour, which is known to be wrong for nested types: the aspect is silently ignored on
+// a nested type even when the nested type carries the attribute itself. See the linked issue. The baseline below
+// will change when that is fixed, which is the point of pinning it here.
+[AutoCancellationToken]
+internal class Outer
+{
+  // Transformed.
+  public async Task OuterAsync(System.Threading.CancellationToken cancellationToken = default) => await Helper(cancellationToken);
+  // Not transformed, as expected: the attribute applies to the members of the type it is applied to.
+  internal class NestedNotAnnotated
+  {
+    public async Task NestedAsync() => await Helper();
+  }
+  // Not transformed, although it should be: the aspect is silently ignored on nested types.
+  [AutoCancellationToken]
+  internal class NestedAnnotated
+  {
+    public async Task NestedAsync() => await Helper();
+  }
+  private static async Task Helper() => await Task.Yield();
+  private static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NonMethodMembers.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NonMethodMembers.cs
@@ -1,0 +1,51 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822, CA2211, CS0067, CA1003
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.NonMethodMembers;
+
+// Regression test for #104: invocations inside members that are not methods used to reach the argument rewriter
+// without an enclosing method, dereferencing a null parameter name and crashing the weaver.
+[AutoCancellationToken]
+internal class NonMethodMembers
+{
+    // Not transformed: an operator has no CancellationToken parameter to propagate.
+    public static NonMethodMembers operator +( NonMethodMembers a, NonMethodMembers b )
+    {
+        Helper( a );
+
+        return a;
+    }
+
+    // Not transformed.
+    public static explicit operator string( NonMethodMembers a )
+    {
+        Helper( a );
+
+        return string.Empty;
+    }
+
+    // Not transformed.
+    public event EventHandler? Changed = CreateHandler();
+
+    // Not transformed.
+    public int Value => Compute();
+
+    // Not transformed.
+    public int this[int index] => Compute();
+
+    // Not transformed.
+    public NonMethodMembers() => Helper( this );
+
+    private static void Helper( NonMethodMembers value ) { }
+
+    private static void Helper( NonMethodMembers value, CancellationToken cancellationToken ) { }
+
+    private static int Compute() => 0;
+
+    private static int Compute( CancellationToken cancellationToken ) => 0;
+
+    private static EventHandler? CreateHandler() => null;
+
+    private static EventHandler? CreateHandler( CancellationToken cancellationToken ) => null;
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NonMethodMembers.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NonMethodMembers.cs
@@ -1,6 +1,9 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822, CA2211, CS0067, CA1003
+#pragma warning disable IDE0021 // Use block body for constructor - the expression body is part of the test.
+#pragma warning disable IDE0051 // Remove unused private members - the token overloads exist so that the
+                                // transformed code has something to bind to.
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.NonMethodMembers;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NonMethodMembers.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/NonMethodMembers.t.cs
@@ -1,0 +1,37 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.NonMethodMembers;
+// Regression test for #104: invocations inside members that are not methods used to reach the argument rewriter
+// without an enclosing method, dereferencing a null parameter name and crashing the weaver.
+[AutoCancellationToken]
+internal class NonMethodMembers
+{
+  // Not transformed: an operator has no CancellationToken parameter to propagate.
+  public static NonMethodMembers operator +(NonMethodMembers a, NonMethodMembers b)
+  {
+    Helper(a);
+    return a;
+  }
+  // Not transformed.
+  public static explicit operator string (NonMethodMembers a)
+  {
+    Helper(a);
+    return string.Empty;
+  }
+  // Not transformed.
+  public event EventHandler? Changed = CreateHandler();
+  // Not transformed.
+  public int Value => Compute();
+  // Not transformed.
+  public int this[int index] => Compute();
+  // Not transformed.
+  public NonMethodMembers() => Helper(this);
+  private static void Helper(NonMethodMembers value)
+  {
+  }
+  private static void Helper(NonMethodMembers value, CancellationToken cancellationToken)
+  {
+  }
+  private static int Compute() => 0;
+  private static int Compute(CancellationToken cancellationToken) => 0;
+  private static EventHandler? CreateHandler() => null;
+  private static EventHandler? CreateHandler(CancellationToken cancellationToken) => null;
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.cs
@@ -1,0 +1,47 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.OverridesAndOverloads;
+
+internal interface IRunner
+{
+    Task RunAsync();
+}
+
+internal abstract class RunnerBase
+{
+    public abstract Task ExecuteAsync();
+
+    public virtual Task VirtualAsync() => Task.CompletedTask;
+}
+
+// Regression test for #105: adding a parameter to a member that overrides or implements another member severs that
+// relationship, and adding one that duplicates an existing overload is a duplicate member.
+[AutoCancellationToken]
+internal class Runner : RunnerBase, IRunner
+{
+    // Not transformed: overrides an abstract member.
+    public override async Task ExecuteAsync() => await Task.Yield();
+
+    // Not transformed: overrides a virtual member.
+    public override async Task VirtualAsync() => await Task.Yield();
+
+    // Not transformed: implicitly implements IRunner.RunAsync.
+    public async Task RunAsync() => await Task.Yield();
+
+    // Not transformed: the type already declares ExistingOverloadAsync(CancellationToken).
+    public async Task ExistingOverloadAsync() => await Task.Yield();
+
+    public async Task ExistingOverloadAsync( CancellationToken cancellationToken ) => await Task.Yield();
+
+    // Transformed: an ordinary async method is unaffected by the new guards.
+    public async Task PlainAsync() => await Task.Yield();
+}
+
+// Not transformed: explicit interface implementation.
+[AutoCancellationToken]
+internal class ExplicitRunner : IRunner
+{
+    async Task IRunner.RunAsync() => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.cs
@@ -16,18 +16,19 @@ internal abstract class RunnerBase
     public virtual Task VirtualAsync() => Task.CompletedTask;
 }
 
-// Regression test for #105: adding a parameter to a member that overrides or implements another member severs that
-// relationship, and adding one that duplicates an existing overload is a duplicate member.
+// Since #81 the original signature is kept and an overload is added, so implicitly implementing an interface
+// member is no longer a problem. Members involved in virtual dispatch are still skipped entirely - see
+// VirtualMembers for why the forwarder-plus-overload approach cannot work for them.
 [AutoCancellationToken]
 internal class Runner : RunnerBase, IRunner
 {
-    // Not transformed: overrides an abstract member.
+    // Not transformed: takes part in virtual dispatch.
     public override async Task ExecuteAsync() => await Task.Yield();
 
-    // Not transformed: overrides a virtual member.
+    // Not transformed: takes part in virtual dispatch.
     public override async Task VirtualAsync() => await Task.Yield();
 
-    // Not transformed: implicitly implements IRunner.RunAsync.
+    // Transformed: the original signature is kept, so IRunner.RunAsync is still implemented.
     public async Task RunAsync() => await Task.Yield();
 
     // Not transformed: the type already declares ExistingOverloadAsync(CancellationToken).
@@ -35,7 +36,7 @@ internal class Runner : RunnerBase, IRunner
 
     public async Task ExistingOverloadAsync( CancellationToken cancellationToken ) => await Task.Yield();
 
-    // Transformed: an ordinary async method is unaffected by the new guards.
+    // Transformed: kept as a forwarder, with the body moved to the new overload.
     public async Task PlainAsync() => await Task.Yield();
 }
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.t.cs
@@ -8,22 +8,27 @@ internal abstract class RunnerBase
   public abstract Task ExecuteAsync();
   public virtual Task VirtualAsync() => Task.CompletedTask;
 }
-// Regression test for #105: adding a parameter to a member that overrides or implements another member severs that
-// relationship, and adding one that duplicates an existing overload is a duplicate member.
+// Since #81 the original signature is kept and an overload is added, so implicitly implementing an interface
+// member is no longer a problem. Members involved in virtual dispatch are still skipped entirely - see
+// VirtualMembers for why the forwarder-plus-overload approach cannot work for them.
 [AutoCancellationToken]
 internal class Runner : RunnerBase, IRunner
 {
-  // Not transformed: overrides an abstract member.
+  // Not transformed: takes part in virtual dispatch.
   public override async Task ExecuteAsync() => await Task.Yield();
-  // Not transformed: overrides a virtual member.
+  // Not transformed: takes part in virtual dispatch.
   public override async Task VirtualAsync() => await Task.Yield();
-  // Not transformed: implicitly implements IRunner.RunAsync.
-  public async Task RunAsync() => await Task.Yield();
+  // Transformed: the original signature is kept, so IRunner.RunAsync is still implemented.
+  public Task RunAsync() => RunAsync(default);
+  // Transformed: the original signature is kept, so IRunner.RunAsync is still implemented.
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken) => await Task.Yield();
   // Not transformed: the type already declares ExistingOverloadAsync(CancellationToken).
   public async Task ExistingOverloadAsync() => await Task.Yield();
   public async Task ExistingOverloadAsync(CancellationToken cancellationToken) => await Task.Yield();
-  // Transformed: an ordinary async method is unaffected by the new guards.
-  public async Task PlainAsync(System.Threading.CancellationToken cancellationToken = default) => await Task.Yield();
+  // Transformed: kept as a forwarder, with the body moved to the new overload.
+  public Task PlainAsync() => PlainAsync(default);
+  // Transformed: kept as a forwarder, with the body moved to the new overload.
+  public async Task PlainAsync(System.Threading.CancellationToken cancellationToken) => await Task.Yield();
 }
 // Not transformed: explicit interface implementation.
 [AutoCancellationToken]

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.t.cs
@@ -1,0 +1,33 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.OverridesAndOverloads;
+internal interface IRunner
+{
+  Task RunAsync();
+}
+internal abstract class RunnerBase
+{
+  public abstract Task ExecuteAsync();
+  public virtual Task VirtualAsync() => Task.CompletedTask;
+}
+// Regression test for #105: adding a parameter to a member that overrides or implements another member severs that
+// relationship, and adding one that duplicates an existing overload is a duplicate member.
+[AutoCancellationToken]
+internal class Runner : RunnerBase, IRunner
+{
+  // Not transformed: overrides an abstract member.
+  public override async Task ExecuteAsync() => await Task.Yield();
+  // Not transformed: overrides a virtual member.
+  public override async Task VirtualAsync() => await Task.Yield();
+  // Not transformed: implicitly implements IRunner.RunAsync.
+  public async Task RunAsync() => await Task.Yield();
+  // Not transformed: the type already declares ExistingOverloadAsync(CancellationToken).
+  public async Task ExistingOverloadAsync() => await Task.Yield();
+  public async Task ExistingOverloadAsync(CancellationToken cancellationToken) => await Task.Yield();
+  // Transformed: an ordinary async method is unaffected by the new guards.
+  public async Task PlainAsync(System.Threading.CancellationToken cancellationToken = default) => await Task.Yield();
+}
+// Not transformed: explicit interface implementation.
+[AutoCancellationToken]
+internal class ExplicitRunner : IRunner
+{
+  async Task IRunner.RunAsync() => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/OverridesAndOverloads.t.cs
@@ -20,14 +20,12 @@ internal class Runner : RunnerBase, IRunner
   public override async Task VirtualAsync() => await Task.Yield();
   // Transformed: the original signature is kept, so IRunner.RunAsync is still implemented.
   public Task RunAsync() => RunAsync(default);
-  // Transformed: the original signature is kept, so IRunner.RunAsync is still implemented.
   public async Task RunAsync(System.Threading.CancellationToken cancellationToken) => await Task.Yield();
   // Not transformed: the type already declares ExistingOverloadAsync(CancellationToken).
   public async Task ExistingOverloadAsync() => await Task.Yield();
   public async Task ExistingOverloadAsync(CancellationToken cancellationToken) => await Task.Yield();
   // Transformed: kept as a forwarder, with the body moved to the new overload.
   public Task PlainAsync() => PlainAsync(default);
-  // Transformed: kept as a forwarder, with the body moved to the new overload.
   public async Task PlainAsync(System.Threading.CancellationToken cancellationToken) => await Task.Yield();
 }
 // Not transformed: explicit interface implementation.

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TransitivePropagation.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TransitivePropagation.cs
@@ -1,0 +1,24 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.TransitivePropagation;
+
+[AutoCancellationToken]
+internal class Caller
+{
+    // The chain stops here. Helper.WorkAsync is in a type the aspect was not applied to, so it never gains a
+    // CancellationToken parameter and there is no overload for the token to be passed to.
+    public async Task RunAsync() => await Helper.WorkAsync();
+}
+
+// Not annotated. The aspect does not add a parameter to WorkAsync even though doing so is what would let a token
+// reach the cancellable call inside it: deciding that requires a fix-point analysis over the call graph.
+internal static class Helper
+{
+    public static async Task WorkAsync() => await Cancellable();
+
+    private static async Task Cancellable() => await Task.Yield();
+
+    private static async Task Cancellable( CancellationToken cancellationToken ) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TransitivePropagation.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TransitivePropagation.cs
@@ -1,6 +1,8 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822
+#pragma warning disable IDE0051 // Remove unused private members - the token overload exists so that the
+                                // transformed code has something to bind to.
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.TransitivePropagation;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TransitivePropagation.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TransitivePropagation.t.cs
@@ -1,0 +1,17 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.TransitivePropagation;
+[AutoCancellationToken]
+internal class Caller
+{
+  // The chain stops here. Helper.WorkAsync is in a type the aspect was not applied to, so it never gains a
+  // CancellationToken parameter and there is no overload for the token to be passed to.
+  public Task RunAsync() => RunAsync(default);
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken) => await Helper.WorkAsync();
+}
+// Not annotated. The aspect does not add a parameter to WorkAsync even though doing so is what would let a token
+// reach the cancellable call inside it: deciding that requires a fix-point analysis over the call graph.
+internal static class Helper
+{
+  public static async Task WorkAsync() => await Cancellable();
+  private static async Task Cancellable() => await Task.Yield();
+  private static async Task Cancellable(CancellationToken cancellationToken) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.cs
@@ -26,6 +26,7 @@ internal record struct RecordStruct
 [AutoCancellationToken]
 internal interface IInterface
 {
+    // A default interface member is implicitly virtual, so it is not transformed and ACT001 is reported.
     async Task RunAsync() => await Helpers.Helper();
 }
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.cs
@@ -1,0 +1,37 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.TypeKinds;
+
+// RewriterBase handles classes, structs, records and interfaces, but only classes were ever tested.
+[AutoCancellationToken]
+internal struct Struct
+{
+    public async Task RunAsync() => await Helpers.Helper();
+}
+
+[AutoCancellationToken]
+internal record Record
+{
+    public async Task RunAsync() => await Helpers.Helper();
+}
+
+[AutoCancellationToken]
+internal record struct RecordStruct
+{
+    public async Task RunAsync() => await Helpers.Helper();
+}
+
+[AutoCancellationToken]
+internal interface IInterface
+{
+    async Task RunAsync() => await Helpers.Helper();
+}
+
+internal static class Helpers
+{
+    public static async Task Helper() => await Task.Yield();
+
+    public static async Task Helper( CancellationToken cancellationToken ) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.t.cs
@@ -1,0 +1,27 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.TypeKinds;
+// RewriterBase handles classes, structs, records and interfaces, but only classes were ever tested.
+[AutoCancellationToken]
+internal struct Struct
+{
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+}
+[AutoCancellationToken]
+internal record Record
+{
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+}
+[AutoCancellationToken]
+internal record struct RecordStruct
+{
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+}
+[AutoCancellationToken]
+internal interface IInterface
+{
+  async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+}
+internal static class Helpers
+{
+  public static async Task Helper() => await Task.Yield();
+  public static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.t.cs
@@ -1,3 +1,4 @@
+// Warning ACT001 on `RunAsync`: `'RunAsync' is not given a CancellationToken parameter because it is virtual, abstract, an override or an explicit interface implementation, and changing such a signature would break the dispatch contract. Its call to 'Helper' therefore runs without cancellation. Declare a CancellationToken parameter on 'RunAsync' explicitly to propagate cancellation.`
 namespace Metalama.Community.AutoCancellationToken.UnitTests.TypeKinds;
 // RewriterBase handles classes, structs, records and interfaces, but only classes were ever tested.
 [AutoCancellationToken]
@@ -21,6 +22,7 @@ internal record struct RecordStruct
 [AutoCancellationToken]
 internal interface IInterface
 {
+  // A default interface member is implicitly virtual, so it is not transformed and ACT001 is reported.
   async Task RunAsync() => await Helpers.Helper();
 }
 internal static class Helpers

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/TypeKinds.t.cs
@@ -3,22 +3,25 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests.TypeKinds;
 [AutoCancellationToken]
 internal struct Struct
 {
-  public async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+  public Task RunAsync() => RunAsync(default);
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken) => await Helpers.Helper(cancellationToken);
 }
 [AutoCancellationToken]
 internal record Record
 {
-  public async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+  public Task RunAsync() => RunAsync(default);
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken) => await Helpers.Helper(cancellationToken);
 }
 [AutoCancellationToken]
 internal record struct RecordStruct
 {
-  public async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+  public Task RunAsync() => RunAsync(default);
+  public async Task RunAsync(System.Threading.CancellationToken cancellationToken) => await Helpers.Helper(cancellationToken);
 }
 [AutoCancellationToken]
 internal interface IInterface
 {
-  async Task RunAsync(System.Threading.CancellationToken cancellationToken = default) => await Helpers.Helper(cancellationToken);
+  async Task RunAsync() => await Helpers.Helper();
 }
 internal static class Helpers
 {

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualCancellationWarning.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualCancellationWarning.cs
@@ -1,0 +1,57 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualCancellationWarning;
+
+// A type the aspect does not touch, so its methods gain no CancellationToken overload.
+internal static class External
+{
+    public static async Task NoTokenOverload() => await Task.Yield();
+
+    public static async Task HasTokenOverload() => await Task.Yield();
+
+    public static async Task HasTokenOverload( CancellationToken cancellationToken ) => await Task.Yield();
+}
+
+// Members that take part in virtual dispatch are never given a CancellationToken parameter, because the signature is
+// the dispatch contract. ACT001 makes the resulting loss of cancellation visible instead of silent, but only when the
+// member would actually have benefited - that is, when its body calls something that would have accepted a token.
+[AutoCancellationToken]
+internal class Base
+{
+    // ACT001: virtual, and the call would have taken the token.
+    public virtual async Task VirtualLosesCancellation() => await External.HasTokenOverload();
+
+    // No ACT001: nothing in the body would have accepted a token.
+    public virtual async Task VirtualGainsNothing() => await External.NoTokenOverload();
+
+    // No ACT001: the author already declared a token, so it is propagated normally.
+    public virtual async Task VirtualWithToken( CancellationToken cancellationToken )
+        => await External.HasTokenOverload();
+
+    // No ACT001: a static local function cannot capture the enclosing token, so nothing was lost by not having one.
+    public virtual async Task VirtualWithStaticLocalFunction()
+    {
+        await Inner();
+
+        static async Task Inner() => await External.HasTokenOverload();
+    }
+
+    // No ACT001: not part of virtual dispatch, so it is transformed normally.
+    public async Task PlainIsTransformed() => await External.HasTokenOverload();
+}
+
+[AutoCancellationToken]
+internal class Derived : Base
+{
+    // ACT001: an override is equally unable to gain a parameter.
+    public override async Task VirtualLosesCancellation() => await External.HasTokenOverload();
+}
+
+[AutoCancellationToken]
+internal abstract class AbstractBase
+{
+    // No ACT001: an abstract member has no body, so there is nothing that could have used a token.
+    public abstract Task AbstractAsync();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualCancellationWarning.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualCancellationWarning.t.cs
@@ -1,0 +1,44 @@
+// Warning ACT001 on `VirtualLosesCancellation`: `'VirtualLosesCancellation' is not given a CancellationToken parameter because it is virtual, abstract, an override or an explicit interface implementation, and changing such a signature would break the dispatch contract. Its call to 'HasTokenOverload' therefore runs without cancellation. Declare a CancellationToken parameter on 'VirtualLosesCancellation' explicitly to propagate cancellation.`
+// Warning ACT001 on `VirtualLosesCancellation`: `'VirtualLosesCancellation' is not given a CancellationToken parameter because it is virtual, abstract, an override or an explicit interface implementation, and changing such a signature would break the dispatch contract. Its call to 'HasTokenOverload' therefore runs without cancellation. Declare a CancellationToken parameter on 'VirtualLosesCancellation' explicitly to propagate cancellation.`
+namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualCancellationWarning;
+// A type the aspect does not touch, so its methods gain no CancellationToken overload.
+internal static class External
+{
+  public static async Task NoTokenOverload() => await Task.Yield();
+  public static async Task HasTokenOverload() => await Task.Yield();
+  public static async Task HasTokenOverload(CancellationToken cancellationToken) => await Task.Yield();
+}
+// Members that take part in virtual dispatch are never given a CancellationToken parameter, because the signature is
+// the dispatch contract. ACT001 makes the resulting loss of cancellation visible instead of silent, but only when the
+// member would actually have benefited - that is, when its body calls something that would have accepted a token.
+[AutoCancellationToken]
+internal class Base
+{
+  // ACT001: virtual, and the call would have taken the token.
+  public virtual async Task VirtualLosesCancellation() => await External.HasTokenOverload();
+  // No ACT001: nothing in the body would have accepted a token.
+  public virtual async Task VirtualGainsNothing() => await External.NoTokenOverload();
+  // No ACT001: the author already declared a token, so it is propagated normally.
+  public virtual async Task VirtualWithToken(CancellationToken cancellationToken) => await External.HasTokenOverload(cancellationToken);
+  // No ACT001: a static local function cannot capture the enclosing token, so nothing was lost by not having one.
+  public virtual async Task VirtualWithStaticLocalFunction()
+  {
+    await Inner();
+    static async Task Inner() => await External.HasTokenOverload();
+  }
+  // No ACT001: not part of virtual dispatch, so it is transformed normally.
+  public Task PlainIsTransformed() => PlainIsTransformed(default);
+  public async Task PlainIsTransformed(System.Threading.CancellationToken cancellationToken) => await External.HasTokenOverload(cancellationToken);
+}
+[AutoCancellationToken]
+internal class Derived : Base
+{
+  // ACT001: an override is equally unable to gain a parameter.
+  public override async Task VirtualLosesCancellation() => await External.HasTokenOverload();
+}
+[AutoCancellationToken]
+internal abstract class AbstractBase
+{
+  // No ACT001: an abstract member has no body, so there is nothing that could have used a token.
+  public abstract Task AbstractAsync();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.cs
@@ -1,0 +1,41 @@
+// Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
+
+#pragma warning disable VSTHRD200, CA1822
+
+namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualMembers;
+
+// Members that take part in virtual dispatch are not transformed. The signature is the dispatch contract, so the
+// forwarder-plus-overload approach of #81 cannot be applied to them:
+//
+//   - Emitting both members as virtual lets a derived class the aspect cannot see override only the original
+//     signature; calling the token-taking overload would then run the base body and ignore the override, silently.
+//   - Emitting only the token-taking overload as virtual would break an existing 'override M()' with CS0506.
+[AutoCancellationToken]
+internal class Base
+{
+    // Not transformed: virtual.
+    public virtual async Task VirtualAsync() => await Helper();
+
+    // Transformed: an ordinary method takes no part in dispatch.
+    public async Task PlainAsync() => await Helper();
+
+    // Transformed: a sealed class' method cannot be overridden either way, but this one is simply not virtual.
+    private async Task PrivateAsync() => await Helper();
+
+    private static async Task Helper() => await Task.Yield();
+
+    private static async Task Helper( CancellationToken cancellationToken ) => await Task.Yield();
+}
+
+[AutoCancellationToken]
+internal abstract class AbstractBase
+{
+    // Not transformed: abstract members have no body to move to an overload.
+    public abstract Task AbstractAsync();
+}
+
+// Stands in for a derived class the aspect never sees: a different assembly, or simply no attribute.
+internal class Derived : Base
+{
+    public override async Task VirtualAsync() => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.cs
@@ -13,7 +13,7 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualMembers;
 [AutoCancellationToken]
 internal class Base
 {
-    // Not transformed: virtual.
+    // Not transformed: virtual. ACT001 is reported because the call to Helper would have taken the token.
     public virtual async Task VirtualAsync() => await Helper();
 
     // Transformed: an ordinary method takes no part in dispatch.

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.cs
@@ -1,6 +1,8 @@
 // Copyright (c) SharpCrafters s.r.o. See the LICENSE.md file in the root directory of this repository root for details.
 
 #pragma warning disable VSTHRD200, CA1822
+#pragma warning disable IDE0051 // Remove unused private members - PrivateAsync shows that a non-virtual
+                                // member is still transformed, and the token overload is a binding target.
 
 namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualMembers;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.t.cs
@@ -12,11 +12,9 @@ internal class Base
   public virtual async Task VirtualAsync() => await Helper();
   // Transformed: an ordinary method takes no part in dispatch.
   public Task PlainAsync() => PlainAsync(default);
-  // Transformed: an ordinary method takes no part in dispatch.
   public async Task PlainAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
   // Transformed: a sealed class' method cannot be overridden either way, but this one is simply not virtual.
   private Task PrivateAsync() => PrivateAsync(default);
-  // Transformed: a sealed class' method cannot be overridden either way, but this one is simply not virtual.
   private async Task PrivateAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
   private static async Task Helper() => await Task.Yield();
   private static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.t.cs
@@ -1,0 +1,34 @@
+namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualMembers;
+// Members that take part in virtual dispatch are not transformed. The signature is the dispatch contract, so the
+// forwarder-plus-overload approach of #81 cannot be applied to them:
+//
+//   - Emitting both members as virtual lets a derived class the aspect cannot see override only the original
+//     signature; calling the token-taking overload would then run the base body and ignore the override, silently.
+//   - Emitting only the token-taking overload as virtual would break an existing 'override M()' with CS0506.
+[AutoCancellationToken]
+internal class Base
+{
+  // Not transformed: virtual.
+  public virtual async Task VirtualAsync() => await Helper();
+  // Transformed: an ordinary method takes no part in dispatch.
+  public Task PlainAsync() => PlainAsync(default);
+  // Transformed: an ordinary method takes no part in dispatch.
+  public async Task PlainAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
+  // Transformed: a sealed class' method cannot be overridden either way, but this one is simply not virtual.
+  private Task PrivateAsync() => PrivateAsync(default);
+  // Transformed: a sealed class' method cannot be overridden either way, but this one is simply not virtual.
+  private async Task PrivateAsync(System.Threading.CancellationToken cancellationToken) => await Helper(cancellationToken);
+  private static async Task Helper() => await Task.Yield();
+  private static async Task Helper(CancellationToken cancellationToken) => await Task.Yield();
+}
+[AutoCancellationToken]
+internal abstract class AbstractBase
+{
+  // Not transformed: abstract members have no body to move to an overload.
+  public abstract Task AbstractAsync();
+}
+// Stands in for a derived class the aspect never sees: a different assembly, or simply no attribute.
+internal class Derived : Base
+{
+  public override async Task VirtualAsync() => await Task.Yield();
+}

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.t.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken.UnitTests/VirtualMembers.t.cs
@@ -1,3 +1,4 @@
+// Warning ACT001 on `VirtualAsync`: `'VirtualAsync' is not given a CancellationToken parameter because it is virtual, abstract, an override or an explicit interface implementation, and changing such a signature would break the dispatch contract. Its call to 'Helper' therefore runs without cancellation. Declare a CancellationToken parameter on 'VirtualAsync' explicitly to propagate cancellation.`
 namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualMembers;
 // Members that take part in virtual dispatch are not transformed. The signature is the dispatch contract, so the
 // forwarder-plus-overload approach of #81 cannot be applied to them:
@@ -8,7 +9,7 @@ namespace Metalama.Community.AutoCancellationToken.UnitTests.VirtualMembers;
 [AutoCancellationToken]
 internal class Base
 {
-  // Not transformed: virtual.
+  // Not transformed: virtual. ACT001 is reported because the call to Helper would have taken the token.
   public virtual async Task VirtualAsync() => await Helper();
   // Transformed: an ordinary method takes no part in dispatch.
   public Task PlainAsync() => PlainAsync(default);

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenArgumentRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenArgumentRewriter.cs
@@ -68,7 +68,10 @@ namespace Metalama.Community.AutoCancellationToken
             }
 
             public override SyntaxNode VisitAnonymousMethodExpression( AnonymousMethodExpressionSyntax node )
-                => VisitFunction( node, false, base.VisitAnonymousMethodExpression );
+                => VisitFunction(
+                    node,
+                    node.Modifiers.Any( SyntaxKind.StaticKeyword ),
+                    base.VisitAnonymousMethodExpression );
 
             public override SyntaxNode VisitParenthesizedLambdaExpression( ParenthesizedLambdaExpressionSyntax node )
                 => VisitFunction(
@@ -101,6 +104,14 @@ namespace Metalama.Community.AutoCancellationToken
 
             public override SyntaxNode VisitInvocationExpression( InvocationExpressionSyntax node )
             {
+                // There is no enclosing method to take the CancellationToken from. This happens for invocations in
+                // members that VisitMethodDeclaration never sees. RewriterBase blocks the member kinds we know of,
+                // but this guard makes an unanticipated one a no-op instead of a crash.
+                if ( this._cancellationTokenParameterName == null )
+                {
+                    return node;
+                }
+
                 var mustAddArgument = false;
 
                 var semanticModel = this._compilation.GetSemanticModel( node.SyntaxTree );

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenArgumentRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenArgumentRewriter.cs
@@ -16,14 +16,17 @@ namespace Metalama.Community.AutoCancellationToken
         {
             private readonly Compilation _compilation;
             private readonly SyntaxAnnotation _generatedCodeAnnotation;
+            private readonly Action<Diagnostic> _reportDiagnostic;
             private string? _cancellationTokenParameterName;
 
             public AddCancellationTokenArgumentRewriter(
                 Compilation compilation,
-                SyntaxAnnotation generatedCodeAnnotation )
+                SyntaxAnnotation generatedCodeAnnotation,
+                Action<Diagnostic> reportDiagnostic )
             {
                 this._compilation = compilation;
                 this._generatedCodeAnnotation = generatedCodeAnnotation;
+                this._reportDiagnostic = reportDiagnostic;
             }
 
             protected override T VisitTypeDeclaration<T>( T node, Func<T, SyntaxNode?> baseVisit )
@@ -50,6 +53,11 @@ namespace Metalama.Community.AutoCancellationToken
                 if ( cancellationTokenParameter == null ||
                      methodSymbol.Parameters.Where( IsCancellationToken ).Count() > 1 )
                 {
+                    if ( cancellationTokenParameter == null )
+                    {
+                        this.ReportIfCancellationIsSilentlyLost( node, methodSymbol, semanticModel );
+                    }
+
                     return node;
                 }
 
@@ -100,6 +108,92 @@ namespace Metalama.Community.AutoCancellationToken
                 return (T) baseVisit( node )!;
             }
 
+            /// <summary>
+            /// Determines whether appending a <see cref="System.Threading.CancellationToken"/> argument to <paramref name="invocation"/>
+            /// would bind to a method whose corresponding parameter is a <see cref="System.Threading.CancellationToken"/>.
+            /// </summary>
+            private static bool WouldAcceptCancellationToken(
+                SemanticModel semanticModel,
+                InvocationExpressionSyntax invocation,
+                out IMethodSymbol? candidate )
+            {
+                var invocationWithCt = invocation.AddArgumentListArguments(
+                    SyntaxFactory.Argument( SyntaxFactory.DefaultExpression( CancellationTokenType ) ) );
+
+                var newInvocationArgumentsCount = invocationWithCt.ArgumentList.Arguments.Count;
+
+                if (
+
+                    // the code compiles
+                    semanticModel.GetSpeculativeSymbolInfo( invocation.SpanStart, invocationWithCt, default ).Symbol is
+                        IMethodSymbol speculativeSymbol &&
+
+                    // the added parameter corresponds to its own argument
+                    speculativeSymbol.Parameters.Length >= newInvocationArgumentsCount &&
+
+                    // that argument is CancellationToken
+                    IsCancellationToken( speculativeSymbol.Parameters[newInvocationArgumentsCount - 1] ) )
+                {
+                    candidate = speculativeSymbol;
+
+                    return true;
+                }
+
+                candidate = null;
+
+                return false;
+            }
+
+            /// <summary>
+            /// Reports <c>ACT001</c> when a member that takes part in virtual dispatch was left without a
+            /// <see cref="System.Threading.CancellationToken"/> parameter although its body calls something that would have accepted
+            /// one. Such a member is deliberately never transformed, because its signature is the dispatch contract,
+            /// but the resulting loss of cancellation would otherwise be entirely silent.
+            /// </summary>
+            private void ReportIfCancellationIsSilentlyLost(
+                MethodDeclarationSyntax node,
+                IMethodSymbol methodSymbol,
+                SemanticModel semanticModel )
+            {
+                if ( !methodSymbol.IsVirtual &&
+                     !methodSymbol.IsAbstract &&
+                     !methodSymbol.IsOverride &&
+                     methodSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty )
+                {
+                    return;
+                }
+
+                // Do not descend into static anonymous functions: they cannot capture a token, so a call inside one
+                // would not have benefited even if the containing method had a parameter.
+                foreach ( var invocation in node
+                             .DescendantNodes( descendIntoChildren: n => !IsStaticAnonymousFunction( n ) )
+                             .OfType<InvocationExpressionSyntax>() )
+                {
+                    if ( WouldAcceptCancellationToken( semanticModel, invocation, out var candidate ) )
+                    {
+                        this._reportDiagnostic(
+                            Diagnostic.Create(
+                                _cancellationNotPropagated,
+                                node.Identifier.GetLocation(),
+                                methodSymbol.Name,
+                                candidate!.Name ) );
+
+                        // One diagnostic per member is enough to make the point.
+                        return;
+                    }
+                }
+            }
+
+            private static bool IsStaticAnonymousFunction( SyntaxNode node )
+                => node switch
+                {
+                    AnonymousMethodExpressionSyntax anonymousMethod => anonymousMethod.Modifiers.Any( SyntaxKind.StaticKeyword ),
+                    ParenthesizedLambdaExpressionSyntax lambda => lambda.Modifiers.Any( SyntaxKind.StaticKeyword ),
+                    SimpleLambdaExpressionSyntax lambda => lambda.Modifiers.Any( SyntaxKind.StaticKeyword ),
+                    LocalFunctionStatementSyntax localFunction => localFunction.Modifiers.Any( SyntaxKind.StaticKeyword ),
+                    _ => false
+                };
+
             public override SyntaxNode VisitInvocationExpression( InvocationExpressionSyntax node )
             {
                 // There is no enclosing method to take the CancellationToken from. This happens for invocations in
@@ -110,29 +204,9 @@ namespace Metalama.Community.AutoCancellationToken
                     return node;
                 }
 
-                var mustAddArgument = false;
-
                 var semanticModel = this._compilation.GetSemanticModel( node.SyntaxTree );
 
-                var invocationWithCt =
-                    node.AddArgumentListArguments( SyntaxFactory.Argument( SyntaxFactory.DefaultExpression( CancellationTokenType ) ) );
-
-                var newInvocationArgumentsCount = invocationWithCt.ArgumentList.Arguments.Count;
-
-                if (
-
-                    // the code compiles
-                    semanticModel.GetSpeculativeSymbolInfo( node.SpanStart, invocationWithCt, default ).Symbol is
-                        IMethodSymbol speculativeSymbol &&
-
-                    // the added parameter corresponds to its own argument
-                    speculativeSymbol.Parameters.Length >= newInvocationArgumentsCount &&
-
-                    // that argument is CancellationToken
-                    IsCancellationToken( speculativeSymbol.Parameters[newInvocationArgumentsCount - 1] ) )
-                {
-                    mustAddArgument = true;
-                }
+                var mustAddArgument = WouldAcceptCancellationToken( semanticModel, node, out _ );
 
                 node = (InvocationExpressionSyntax?) base.VisitInvocationExpression( node )!;
 

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenArgumentRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenArgumentRewriter.cs
@@ -27,17 +27,15 @@ namespace Metalama.Community.AutoCancellationToken
             }
 
             protected override T VisitTypeDeclaration<T>( T node, Func<T, SyntaxNode?> baseVisit )
+                => this.VisitTypeDeclarationCore( node, baseVisit );
+
+            public override SyntaxNode? VisitMethodDeclaration( MethodDeclarationSyntax node )
             {
-                if ( !node.HasAnnotation( AnnotateNodesRewriter.Annotation ) )
+                if ( !this.IsInAnnotatedType )
                 {
                     return node;
                 }
 
-                return (T) baseVisit( node )!;
-            }
-
-            public override SyntaxNode? VisitMethodDeclaration( MethodDeclarationSyntax node )
-            {
                 var semanticModel = this._compilation.GetSemanticModel( node.SyntaxTree );
 
                 var methodSymbol = semanticModel.GetDeclaredSymbol( node );

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
@@ -132,8 +132,13 @@ namespace Metalama.Community.AutoCancellationToken
                             null )
                         .WithAdditionalAnnotations( this._generatedCodeAnnotation ) );
 
-                return method.WithParameterList(
-                    SyntaxFactory.ParameterList( SyntaxFactory.SeparatedList<ParameterSyntax>( [..parameters] ) ) );
+                return method
+                    .WithParameterList(
+                        SyntaxFactory.ParameterList( SyntaxFactory.SeparatedList<ParameterSyntax>( [..parameters] ) ) )
+
+                    // Both members are built from the same declaration, so without this the original's comments and
+                    // documentation would appear twice: once above the forwarder and again above the overload.
+                    .WithLeadingTrivia( SyntaxFactory.ElasticCarriageReturnLineFeed );
             }
 
             public override SyntaxNode VisitMethodDeclaration( MethodDeclarationSyntax node )

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
@@ -48,6 +48,21 @@ namespace Metalama.Community.AutoCancellationToken
                     return node;
                 }
 
+                // Widening the signature of a method that overrides or implements another member would sever that
+                // relationship and produce code that does not compile.
+                if ( methodSymbol.IsOverride ||
+                     !methodSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
+                     ImplementsInterfaceMember( methodSymbol ) )
+                {
+                    return node;
+                }
+
+                // Adding the parameter must not produce a duplicate of a method that already exists in the type.
+                if ( WouldCollideWithExistingMember( methodSymbol ) )
+                {
+                    return node;
+                }
+
                 // TODO: Review: finding a unique name is a common pattern. Is there a common library implementation?
                 const string defaultParameterName = "cancellationToken";
                 var useParameterName = defaultParameterName;
@@ -101,6 +116,88 @@ namespace Metalama.Community.AutoCancellationToken
                     SyntaxFactory.ParameterList( SyntaxFactory.SeparatedList<ParameterSyntax>( [..parameters] ) ) );
 
                 return node;
+            }
+
+            /// <summary>
+            /// Determines whether <paramref name="method"/> implicitly implements a member of an interface implemented
+            /// by its containing type. Explicit implementations are reported by <see cref="ISymbol.ExplicitInterfaceImplementations"/>
+            /// and are checked separately.
+            /// </summary>
+            private static bool ImplementsInterfaceMember( IMethodSymbol method )
+            {
+                var containingType = method.ContainingType;
+
+                if ( containingType == null )
+                {
+                    return false;
+                }
+
+                foreach ( var interfaceType in containingType.AllInterfaces )
+                {
+                    foreach ( var interfaceMember in interfaceType.GetMembers( method.Name ) )
+                    {
+                        if ( interfaceMember is IMethodSymbol &&
+                             SymbolEqualityComparer.Default.Equals(
+                                 containingType.FindImplementationForInterfaceMember( interfaceMember ),
+                                 method ) )
+                        {
+                            return true;
+                        }
+                    }
+                }
+
+                return false;
+            }
+
+            /// <summary>
+            /// Determines whether adding a trailing <see cref="System.Threading.CancellationToken"/> parameter to
+            /// <paramref name="method"/> would produce a signature that another member of the same type already has.
+            /// </summary>
+            private static bool WouldCollideWithExistingMember( IMethodSymbol method )
+            {
+                var containingType = method.ContainingType;
+
+                if ( containingType == null )
+                {
+                    return false;
+                }
+
+                foreach ( var member in containingType.GetMembers( method.Name ) )
+                {
+                    if ( member is not IMethodSymbol otherMethod ||
+                         SymbolEqualityComparer.Default.Equals( otherMethod, method ) ||
+                         otherMethod.Parameters.Length != method.Parameters.Length + 1 ||
+                         otherMethod.TypeParameters.Length != method.TypeParameters.Length )
+                    {
+                        continue;
+                    }
+
+                    if ( !IsCancellationToken( otherMethod.Parameters[otherMethod.Parameters.Length - 1] ) )
+                    {
+                        continue;
+                    }
+
+                    var parametersMatch = true;
+
+                    for ( var i = 0; i < method.Parameters.Length; i++ )
+                    {
+                        if ( !SymbolEqualityComparer.Default.Equals(
+                                otherMethod.Parameters[i].Type,
+                                method.Parameters[i].Type ) )
+                        {
+                            parametersMatch = false;
+
+                            break;
+                        }
+                    }
+
+                    if ( parametersMatch )
+                    {
+                        return true;
+                    }
+                }
+
+                return false;
             }
         }
     }

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
@@ -5,6 +5,7 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using System;
+using System.Collections.Generic;
 using System.Linq;
 
 namespace Metalama.Community.AutoCancellationToken
@@ -67,20 +68,23 @@ namespace Metalama.Community.AutoCancellationToken
                 const string defaultParameterName = "cancellationToken";
                 var useParameterName = defaultParameterName;
 
-                if ( methodSymbol.Parameters.Length > 0 )
+                // The name must not collide with a parameter, a type parameter, or anything declared in the body:
+                // a local declared in an enclosing scope of a nested one causes CS0136, and reusing the name of an
+                // existing local would silently pass that local instead of the token. Collecting every identifier in
+                // the declaration is a deliberate over-approximation - it can only make us pick a longer name.
+                var usedNames = new HashSet<string>( StringComparer.Ordinal );
+
+                foreach ( var token in node.DescendantTokens() )
                 {
-                    for ( var i = 2; /* Intentionally empty*/; ++i )
+                    if ( token.IsKind( SyntaxKind.IdentifierToken ) )
                     {
-                        // ReSharper disable once AccessToModifiedClosure
-                        if ( methodSymbol.Parameters.Any( p => p.Name == useParameterName ) )
-                        {
-                            useParameterName = $"{defaultParameterName}{i}";
-                        }
-                        else
-                        {
-                            break;
-                        }
+                        usedNames.Add( token.ValueText );
                     }
+                }
+
+                for ( var i = 2; usedNames.Contains( useParameterName ); ++i )
+                {
+                    useParameterName = $"{defaultParameterName}{i}";
                 }
 
                 var parameters = node.ParameterList.Parameters.GetWithSeparators().ToList();

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AddCancellationTokenParameterRewriter.cs
@@ -26,18 +26,123 @@ namespace Metalama.Community.AutoCancellationToken
                 this._generatedCodeAnnotation = generatedCodeAnnotation;
             }
 
+            /// <summary>
+            /// Kind of the annotation that marks a method to be split into a forwarder and an overload. Its data is
+            /// the name chosen for the <see cref="System.Threading.CancellationToken"/> parameter.
+            /// </summary>
+            private const string _expandAnnotationKind = "Metalama.Community.AutoCancellationToken.Expand";
+
             protected override T VisitTypeDeclaration<T>( T node, Func<T, SyntaxNode?> baseVisit )
             {
-                if ( !node.HasAnnotation( AnnotateNodesRewriter.Annotation ) )
+                var visited = this.VisitTypeDeclarationCore( node, baseVisit );
+
+                // A method cannot replace itself with two members, so VisitMethodDeclaration only marks the methods
+                // to expand and the expansion happens here, where the member list is available.
+                return (T) this.ExpandMarkedMethods( visited );
+            }
+
+            private TypeDeclarationSyntax ExpandMarkedMethods( TypeDeclarationSyntax type )
+            {
+                if ( !type.Members.Any( m => m.GetAnnotations( _expandAnnotationKind ).Any() ) )
                 {
-                    return node;
+                    return type;
                 }
 
-                return (T) baseVisit( node )!;
+                var members = new List<MemberDeclarationSyntax>( type.Members.Count + 1 );
+
+                foreach ( var member in type.Members )
+                {
+                    if ( member is MethodDeclarationSyntax method &&
+                         method.GetAnnotations( _expandAnnotationKind ).FirstOrDefault() is { } annotation )
+                    {
+                        var parameterName = annotation.Data!;
+                        var original = method.WithoutAnnotations( _expandAnnotationKind );
+
+                        members.Add( CreateForwarder( original, this._generatedCodeAnnotation ) );
+                        members.Add( this.CreateOverload( original, parameterName ) );
+                    }
+                    else
+                    {
+                        members.Add( member );
+                    }
+                }
+
+                return type.WithMembers( SyntaxFactory.List( members ) );
+            }
+
+            /// <summary>
+            /// Builds the method that keeps the original signature and simply calls the new overload. Keeping it means
+            /// existing callers, overrides and interface implementations are unaffected (#81).
+            /// </summary>
+            private static MethodDeclarationSyntax CreateForwarder(
+                MethodDeclarationSyntax method,
+                SyntaxAnnotation generatedCodeAnnotation )
+            {
+                SimpleNameSyntax name = method.TypeParameterList is { Parameters.Count: > 0 } typeParameters
+                    ? SyntaxFactory.GenericName(
+                        method.Identifier,
+                        SyntaxFactory.TypeArgumentList(
+                            SyntaxFactory.SeparatedList<TypeSyntax>(
+                                typeParameters.Parameters.Select( p => SyntaxFactory.IdentifierName( p.Identifier ) ) ) ) )
+                    : SyntaxFactory.IdentifierName( method.Identifier );
+
+                var arguments = method.ParameterList.Parameters
+                    .Select( p => SyntaxFactory.Argument( SyntaxFactory.IdentifierName( p.Identifier ) ) )
+                    .Append( SyntaxFactory.Argument( SyntaxFactory.LiteralExpression( SyntaxKind.DefaultLiteralExpression ) ) );
+
+                var invocation = SyntaxFactory.InvocationExpression(
+                    name,
+                    SyntaxFactory.ArgumentList( SyntaxFactory.SeparatedList( arguments ) ) );
+
+                // The forwarder is not async: it returns the overload's task directly. That avoids CS1998, keeps
+                // async iterators working, and is correct for an async void method too.
+                return method
+                    .WithModifiers(
+                        SyntaxFactory.TokenList( method.Modifiers.Where( m => !m.IsKind( SyntaxKind.AsyncKeyword ) ) ) )
+                    .WithBody( null )
+                    .WithExpressionBody( SyntaxFactory.ArrowExpressionClause( invocation ) )
+                    .WithSemicolonToken( SyntaxFactory.Token( SyntaxKind.SemicolonToken ) )
+                    .WithAdditionalAnnotations( generatedCodeAnnotation );
+            }
+
+            /// <summary>
+            /// Builds the overload that carries the original body and takes the token. The parameter deliberately has
+            /// no default value: with one, a call using the original argument list would be ambiguous (CS0121).
+            /// </summary>
+            private MethodDeclarationSyntax CreateOverload( MethodDeclarationSyntax method, string parameterName )
+            {
+                var parameters = method.ParameterList.Parameters.GetWithSeparators().ToList();
+
+                if ( parameters.Count > 0 )
+                {
+                    parameters[parameters.Count - 1] = parameters[parameters.Count - 1].AsNode()!.WithoutTrailingTrivia();
+
+                    parameters.Add(
+                        SyntaxFactory.Token( SyntaxKind.CommaToken )
+                            .WithTrailingTrivia( SyntaxFactory.ElasticSpace )
+                            .WithAdditionalAnnotations( this._generatedCodeAnnotation ) );
+                }
+
+                parameters.Add(
+                    SyntaxFactory.Parameter(
+                            default,
+                            default,
+                            CancellationTokenType.WithTrailingTrivia( SyntaxFactory.ElasticSpace ),
+                            SyntaxFactory.Identifier( parameterName ),
+                            null )
+                        .WithAdditionalAnnotations( this._generatedCodeAnnotation ) );
+
+                return method.WithParameterList(
+                    SyntaxFactory.ParameterList( SyntaxFactory.SeparatedList<ParameterSyntax>( [..parameters] ) ) );
             }
 
             public override SyntaxNode VisitMethodDeclaration( MethodDeclarationSyntax node )
             {
+                if ( !this.IsInAnnotatedType )
+                {
+                    return node;
+                }
+
                 var semanticModel = this._compilation.GetSemanticModel( node.SyntaxTree );
 
                 var methodSymbol = semanticModel.GetDeclaredSymbol( node );
@@ -49,16 +154,26 @@ namespace Metalama.Community.AutoCancellationToken
                     return node;
                 }
 
-                // Widening the signature of a method that overrides or implements another member would sever that
-                // relationship and produce code that does not compile.
-                if ( methodSymbol.IsOverride ||
-                     !methodSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty ||
-                     ImplementsInterfaceMember( methodSymbol ) )
+                // A member that takes part in virtual dispatch cannot be split into a forwarder plus an overload,
+                // because the signature is the dispatch contract:
+                //
+                //   - If both members are virtual, a derived class the aspect cannot see overrides only the original
+                //     signature. Calling the token-taking overload then runs the base body and silently ignores the
+                //     override. That code compiles, which makes the breakage worse.
+                //   - If only the token-taking overload is virtual, an existing 'override M()' no longer compiles
+                //     (CS0506) - the very breaking change #81 asks us to avoid.
+                //
+                // Transforming an override is only sound when the base type was transformed too, which we cannot rely
+                // on across an assembly boundary. So every member involved in virtual dispatch is left alone.
+                if ( methodSymbol.IsVirtual ||
+                     methodSymbol.IsAbstract ||
+                     methodSymbol.IsOverride ||
+                     !methodSymbol.ExplicitInterfaceImplementations.IsDefaultOrEmpty )
                 {
                     return node;
                 }
 
-                // Adding the parameter must not produce a duplicate of a method that already exists in the type.
+                // The overload must not duplicate a method that already exists in the type.
                 if ( WouldCollideWithExistingMember( methodSymbol ) )
                 {
                     return node;
@@ -87,70 +202,9 @@ namespace Metalama.Community.AutoCancellationToken
                     useParameterName = $"{defaultParameterName}{i}";
                 }
 
-                var parameters = node.ParameterList.Parameters.GetWithSeparators().ToList();
-
-                if ( parameters.Count > 0 )
-                {
-                    // Remove the trivia after the last argument.
-                    parameters[parameters.Count - 1] =
-                        parameters[parameters.Count - 1].AsNode()!.WithoutTrailingTrivia();
-
-                    parameters.Add(
-                        SyntaxFactory.Token( SyntaxKind.CommaToken )
-                            .WithTrailingTrivia( SyntaxFactory.ElasticSpace )
-                            .WithAdditionalAnnotations( this._generatedCodeAnnotation ) );
-                }
-
-                parameters.Add(
-                    SyntaxFactory.Parameter(
-                            default,
-                            default,
-                            CancellationTokenType.WithTrailingTrivia( SyntaxFactory.ElasticSpace ),
-                            SyntaxFactory.Identifier( useParameterName )
-                                .WithTrailingTrivia( SyntaxFactory.ElasticSpace ),
-                            SyntaxFactory.EqualsValueClause(
-                                    SyntaxFactory.Token( SyntaxKind.EqualsToken )
-                                        .WithTrailingTrivia( SyntaxFactory.ElasticSpace ),
-                                    SyntaxFactory.LiteralExpression( SyntaxKind.DefaultLiteralExpression ) )
-                                .WithTrailingTrivia( SyntaxFactory.ElasticSpace ) )
-                        .WithTrailingTrivia( SyntaxFactory.ElasticSpace )
-                        .WithAdditionalAnnotations( this._generatedCodeAnnotation ) );
-
-                node = node.WithParameterList(
-                    SyntaxFactory.ParameterList( SyntaxFactory.SeparatedList<ParameterSyntax>( [..parameters] ) ) );
-
-                return node;
-            }
-
-            /// <summary>
-            /// Determines whether <paramref name="method"/> implicitly implements a member of an interface implemented
-            /// by its containing type. Explicit implementations are reported by <see cref="ISymbol.ExplicitInterfaceImplementations"/>
-            /// and are checked separately.
-            /// </summary>
-            private static bool ImplementsInterfaceMember( IMethodSymbol method )
-            {
-                var containingType = method.ContainingType;
-
-                if ( containingType == null )
-                {
-                    return false;
-                }
-
-                foreach ( var interfaceType in containingType.AllInterfaces )
-                {
-                    foreach ( var interfaceMember in interfaceType.GetMembers( method.Name ) )
-                    {
-                        if ( interfaceMember is IMethodSymbol &&
-                             SymbolEqualityComparer.Default.Equals(
-                                 containingType.FindImplementationForInterfaceMember( interfaceMember ),
-                                 method ) )
-                        {
-                            return true;
-                        }
-                    }
-                }
-
-                return false;
+                // Only mark the method here. The expansion into a forwarder plus an overload happens in
+                // VisitTypeDeclaration, where the member list can be replaced.
+                return node.WithAdditionalAnnotations( new SyntaxAnnotation( _expandAnnotationKind, useParameterName ) );
             }
 
             /// <summary>

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AnnotateNodesRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AnnotateNodesRewriter.cs
@@ -28,7 +28,7 @@ namespace Metalama.Community.AutoCancellationToken
                 var visited = (T) baseVisit( node )!;
 
                 return this._instancesNodes.Contains( node )
-                    ? (T) visited.WithAdditionalAnnotations( Annotation )
+                    ? visited.WithAdditionalAnnotations( Annotation )
                     : visited;
             }
         }

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AnnotateNodesRewriter.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.AnnotateNodesRewriter.cs
@@ -23,12 +23,13 @@ namespace Metalama.Community.AutoCancellationToken
 
             protected override T VisitTypeDeclaration<T>( T node, Func<T, SyntaxNode?> baseVisit )
             {
-                if ( !this._instancesNodes.Contains( node ) )
-                {
-                    return node;
-                }
+                // Always descend, even into a type that does not carry the aspect: a nested type may carry it itself,
+                // and returning early here made the aspect a silent no-op on nested types (#109).
+                var visited = (T) baseVisit( node )!;
 
-                return node.WithAdditionalAnnotations( Annotation );
+                return this._instancesNodes.Contains( node )
+                    ? (T) visited.WithAdditionalAnnotations( Annotation )
+                    : visited;
             }
         }
     }

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.RewriterBase.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.RewriterBase.cs
@@ -27,6 +27,37 @@ namespace Metalama.Community.AutoCancellationToken
             protected abstract T VisitTypeDeclaration<T>( T node, Func<T, SyntaxNode?> baseVisit )
                 where T : TypeDeclarationSyntax;
 
+            /// <summary>
+            /// Gets a value indicating whether the type currently being visited carries the aspect.
+            /// </summary>
+            protected bool IsInAnnotatedType { get; private set; }
+
+            /// <summary>
+            /// Descends into <paramref name="node"/> while recording whether it carries the aspect, so that members
+            /// are transformed only when their own containing type is annotated.
+            /// </summary>
+            /// <remarks>
+            /// Descending unconditionally is what makes the aspect work on a nested type (#109). The previous
+            /// implementation returned early for a type without the annotation, so a nested annotated type was never
+            /// reached. Because <see cref="CSharpSyntaxRewriter.VisitMethodDeclaration"/> does not itself know which
+            /// type it is in, the flag has to be saved and restored around the recursion.
+            /// </remarks>
+            protected T VisitTypeDeclarationCore<T>( T node, Func<T, SyntaxNode?> baseVisit )
+                where T : TypeDeclarationSyntax
+            {
+                var previous = this.IsInAnnotatedType;
+                this.IsInAnnotatedType = node.HasAnnotation( AnnotateNodesRewriter.Annotation );
+
+                try
+                {
+                    return (T) baseVisit( node )!;
+                }
+                finally
+                {
+                    this.IsInAnnotatedType = previous;
+                }
+            }
+
             protected static readonly TypeSyntax CancellationTokenType = SyntaxFactory
                 .ParseTypeName( typeof(CancellationToken).FullName! )
                 .WithSimplifierAnnotation();

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.RewriterBase.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.RewriterBase.cs
@@ -34,18 +34,27 @@ namespace Metalama.Community.AutoCancellationToken
             protected static bool IsCancellationToken( IParameterSymbol parameter )
                 => parameter.OriginalDefinition.Type.ToString() == typeof(CancellationToken).FullName;
 
-            // Make sure VisitInvocationExpression is not called for expressions inside members that are not methods
+            // Make sure VisitInvocationExpression is not called for expressions inside members that are not methods.
+            // Note that this list is not the only line of defence: AddCancellationTokenArgumentRewriter also ignores
+            // invocations reached without an enclosing method, so an unanticipated member kind cannot crash the weaver.
             public override SyntaxNode VisitPropertyDeclaration( PropertyDeclarationSyntax node ) => node;
 
             public override SyntaxNode VisitIndexerDeclaration( IndexerDeclarationSyntax node ) => node;
 
             public override SyntaxNode VisitEventDeclaration( EventDeclarationSyntax node ) => node;
 
+            // Field-like events (event EventHandler E = Handler();) are a different node type than EventDeclarationSyntax.
+            public override SyntaxNode VisitEventFieldDeclaration( EventFieldDeclarationSyntax node ) => node;
+
             public override SyntaxNode VisitFieldDeclaration( FieldDeclarationSyntax node ) => node;
 
             public override SyntaxNode VisitConstructorDeclaration( ConstructorDeclarationSyntax node ) => node;
 
             public override SyntaxNode VisitDestructorDeclaration( DestructorDeclarationSyntax node ) => node;
+
+            public override SyntaxNode VisitOperatorDeclaration( OperatorDeclarationSyntax node ) => node;
+
+            public override SyntaxNode VisitConversionOperatorDeclaration( ConversionOperatorDeclarationSyntax node ) => node;
         }
     }
 }

--- a/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.cs
+++ b/src/Metalama.Community.AutoCancellationToken/Metalama.Community.AutoCancellationToken/AutoCancellationTokenWeaver.cs
@@ -3,6 +3,7 @@
 using Metalama.Framework.Engine;
 using Metalama.Framework.Engine.AspectWeavers;
 using Metalama.Framework.Engine.CodeModel;
+using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
 using System.Linq;
 using System.Threading.Tasks;
@@ -12,6 +13,22 @@ namespace Metalama.Community.AutoCancellationToken
     [MetalamaPlugIn]
     internal partial class AutoCancellationTokenWeaver : IAspectWeaver
     {
+        /// <summary>
+        /// Reported when a member that takes part in virtual dispatch is left untransformed although its body calls
+        /// something that would have accepted a <see cref="System.Threading.CancellationToken"/>. Without this, the
+        /// loss of cancellation is entirely silent.
+        /// </summary>
+        private static readonly DiagnosticDescriptor _cancellationNotPropagated = new(
+            "ACT001",
+            "Cancellation is not propagated to a member that takes part in virtual dispatch",
+            "'{0}' is not given a CancellationToken parameter because it is virtual, abstract, an override or an "
+            + "explicit interface implementation, and changing such a signature would break the dispatch contract. "
+            + "Its call to '{1}' therefore runs without cancellation. Declare a CancellationToken parameter on '{0}' "
+            + "explicitly to propagate cancellation.",
+            "Metalama.Community.AutoCancellationToken",
+            DiagnosticSeverity.Warning,
+            true );
+
         public async Task TransformAsync( AspectWeaverContext context )
         {
             var compilation = context.Compilation;
@@ -26,10 +43,14 @@ namespace Metalama.Community.AutoCancellationToken
                     compilation.Compilation,
                     context.GeneratedCodeAnnotation ) );
 
+            // This pass runs after the parameter pass, so a method that has just gained a CancellationToken overload
+            // is already visible here. That matters for the ACT001 diagnostic, which asks whether a call could have
+            // accepted a token.
             await RunRewriterAsync(
                 new AddCancellationTokenArgumentRewriter(
                     compilation.Compilation,
-                    context.GeneratedCodeAnnotation ) );
+                    context.GeneratedCodeAnnotation,
+                    context.ReportDiagnostic ) );
 
             context.Compilation = compilation;
 

--- a/src/Metalama.Community.AutoCancellationToken/README.md
+++ b/src/Metalama.Community.AutoCancellationToken/README.md
@@ -7,6 +7,18 @@ Automatically propagates `CancellationToken` parameter to `async` methods and me
 
 <!-- [![CI badge](https://github.com/postsharp/Metalama.Community.AutoCancellationToken/workflows/Full%20Pipeline/badge.svg)](https://github.com/postsharp/Metalama.Community.AutoCancellationToken/actions?query=workflow%3A%22Full+Pipeline%22) -->
 
+> ### ⚠️ Proof of concept
+>
+> **This aspect is a proof of concept, not a production-ready tool. Do not rely on it to make an application
+> correctly cancellable.**
+>
+> Cancellation is a semantic decision, but this aspect works purely syntactically: it passes a token to a call
+> because an overload happens to accept one. It has no way to know which calls *should* honour cancellation and
+> which must always run to completion — cleanup, disposal, compensating writes, audit logging. Cancelling those
+> causes resource leaks and partially applied state.
+>
+> Read the [limitations](#limitations) below before using it. Several of them fail silently.
+
 #### Example
 
 Your code:
@@ -36,12 +48,17 @@ class C
         await MakeRequest(client, ct);
     }
 
-    private static async Task MakeRequest(HttpClient client, CancellationToken cancellationToken = default) => await client.GetAsync("https://example.org", cancellationToken);
+    // The original signature is kept, so existing callers still compile.
+    private static Task MakeRequest(HttpClient client) => MakeRequest(client, default);
+
+    // The body moves to a new overload that takes the token.
+    private static async Task MakeRequest(HttpClient client, CancellationToken cancellationToken)
+        => await client.GetAsync("https://example.org", cancellationToken);
 }
 ```
 
-Notice that `CancellationToken` parameter was added to the declaration of `MakeRequest` and that `CancellationToken`
-argument was added to the calls of `MakeRequest` and `HttpClient.GetAsync`.
+Notice that the call to `MakeRequest` now passes `ct`, that `MakeRequest` gained an overload taking a
+`CancellationToken`, and that the call to `HttpClient.GetAsync` passes it on.
 
 #### Installation
 Install the NuGet package: `dotnet add package Metalama.Community.AutoCancellationToken`.
@@ -50,13 +67,46 @@ Install the NuGet package: `dotnet add package Metalama.Community.AutoCancellati
 
 Add `[AutoCancellationToken]` to the types where you want it to apply.
 
-By annotating a type with `[AutoCancellationToken]`, you add cancellation to all its `async` methods. Specifically:
+By annotating a type with `[AutoCancellationToken]`, you add cancellation to its `async` methods. Specifically:
 
-* A `CancellationToken` parameter is added to all `async` methods that don't have it.
+* For each `async` method that has no `CancellationToken` parameter, the original method is kept as a forwarder and
+  an overload taking a `CancellationToken` is added. The original signature is never changed, so existing callers
+  keep compiling.
 * A `CancellationToken` argument is added to calls within `async` methods where:
-    * `CancellationToken` can be added as a last argument and the added argument corresponds to a `CancellationToken`
-      parameter (e.g. it's not a `params object[]` parameter or a generic parameter). The added argument can result in
-      calling a different overload of the method, or specifying a value for an optional parameter.
-    * The call is not in a `static` local function.
-    * The containing method doesn't have two or more `CancellationToken` parameters, since it wouldn't be clear which
-      one to use.
+    * `CancellationToken` can be added as a last argument and the added argument corresponds to a
+      `CancellationToken` parameter (e.g. it's not a `params object[]` parameter or a generic parameter). The added
+      argument can result in calling a different overload of the method, or specifying a value for an optional
+      parameter.
+    * The call is not in a `static` local function or a `static` lambda, which cannot capture the enclosing token.
+    * The containing method doesn't have two or more `CancellationToken` parameters, since it wouldn't be clear
+      which one to use.
+
+#### Limitations
+
+**The aspect decides what to cancel from syntax alone.** It cannot tell a cancellable operation from one that must
+complete. If a method in an annotated type performs cleanup, disposal or logging through a call that offers a
+`CancellationToken` overload, the aspect will pass the token and that work becomes cancellable. Review the
+generated code before depending on it.
+
+**Callers of the original signature never cancel.** The forwarder passes `default`, i.e. `CancellationToken.None`.
+Code outside the aspect's reach keeps compiling, but gains no cancellation at all — silently. Only callers within
+annotated types have the token propagated to them.
+
+**Members involved in virtual dispatch are not transformed.** `virtual`, `abstract` and `override` methods, and
+explicit interface implementations, are skipped entirely and receive no cancellation support. A method's signature
+is its dispatch contract: adding an overload would let a derived class the aspect cannot see override only the
+original signature, so calling the token-taking overload would run the base body and silently ignore the override.
+Making only the overload virtual would instead break existing `override` declarations.
+
+**The aspect only sees the current compilation.** It cannot add tokens to methods in referenced assemblies, and it
+cannot know whether a type deriving from yours will be transformed.
+
+**Several constructs are skipped rather than reported.** A method whose last parameter is a `params` array, a
+method that already declares two or more `CancellationToken` parameters, and a call whose candidate overload takes
+a generic final parameter are all left untouched without a diagnostic. Nothing tells you the aspect did nothing.
+
+**Async iterators are not given `[EnumeratorCancellation]`.** The token added to an `async IAsyncEnumerable<T>`
+method is not wired up to the enumerator, so a token passed to `WithCancellation` is unconsumed. This is the one
+limitation the compiler does warn about, as `CS8425`.
+
+If you need cancellation you can rely on, thread `CancellationToken` through explicitly.

--- a/src/Metalama.Community.AutoCancellationToken/README.md
+++ b/src/Metalama.Community.AutoCancellationToken/README.md
@@ -98,6 +98,40 @@ is its dispatch contract: adding an overload would let a derived class the aspec
 original signature, so calling the token-taking overload would run the base body and silently ignore the override.
 Making only the overload virtual would instead break existing `override` declarations.
 
+**Propagation is not transitive, so a chain breaks at the first method the aspect does not own.** The aspect adds a
+token to the `async` methods of annotated types and then passes it to calls that already accept one. It never adds a
+parameter to a method merely because doing so is what would let the token travel further:
+
+```csharp
+[AutoCancellationToken]
+class Caller
+{
+    // WorkAsync is in a type the aspect was not applied to, so it never gains a CancellationToken parameter and
+    // there is no overload to pass the token to. The chain stops here, even though the cancellable call is one
+    // hop away.
+    async Task RunAsync() => await Helper.WorkAsync();
+}
+
+static class Helper
+{
+    public static async Task WorkAsync() => await Cancellable();
+}
+```
+
+Closing that gap means deciding, for every method, whether it transitively reaches a call that can be cancelled —
+and adding a parameter to one method changes the answer for all of its callers, so the analysis has to be iterated
+to a fix point. That is possible, but generally out of scope for a build-time transformation because of its cost,
+and impossible across an assembly boundary. Annotating every type involved in a call chain is the practical
+workaround.
+
+**Conversely, within an annotated type the aspect over-approximates.** Because it does not analyse which methods
+need a token, *every* `async` method gets one, including methods that never use it:
+
+```csharp
+public Task DoNothingAsync() => DoNothingAsync(default);
+public async Task DoNothingAsync(CancellationToken cancellationToken) => await Task.Yield(); // unused
+```
+
 **The aspect only sees the current compilation.** It cannot add tokens to methods in referenced assemblies, and it
 cannot know whether a type deriving from yours will be transformed.
 

--- a/src/Metalama.Community.AutoCancellationToken/README.md
+++ b/src/Metalama.Community.AutoCancellationToken/README.md
@@ -98,6 +98,18 @@ is its dispatch contract: adding an overload would let a derived class the aspec
 original signature, so calling the token-taking overload would run the base body and silently ignore the override.
 Making only the overload virtual would instead break existing `override` declarations.
 
+This one is *not* silent. When such a member calls something that would have accepted a token, the aspect reports
+the warning `ACT001`, so you can see where cancellation was dropped and add a `CancellationToken` parameter by hand:
+
+```
+warning ACT001: 'RunAsync' is not given a CancellationToken parameter because it is virtual, abstract, an override
+or an explicit interface implementation, and changing such a signature would break the dispatch contract. Its call
+to 'GetAsync' therefore runs without cancellation. Declare a CancellationToken parameter on 'RunAsync' explicitly
+to propagate cancellation.
+```
+
+Declaring the parameter yourself resolves it: the aspect then propagates that token through the body as usual.
+
 **Propagation is not transitive, so a chain breaks at the first method the aspect does not own.** The aspect adds a
 token to the `async` methods of annotated types and then passes it to calls that already accept one. It never adds a
 parameter to a method merely because doing so is what would let the token travel further:
@@ -135,9 +147,10 @@ public async Task DoNothingAsync(CancellationToken cancellationToken) => await T
 **The aspect only sees the current compilation.** It cannot add tokens to methods in referenced assemblies, and it
 cannot know whether a type deriving from yours will be transformed.
 
-**Several constructs are skipped rather than reported.** A method whose last parameter is a `params` array, a
-method that already declares two or more `CancellationToken` parameters, and a call whose candidate overload takes
-a generic final parameter are all left untouched without a diagnostic. Nothing tells you the aspect did nothing.
+**Several constructs are still skipped without being reported.** A method whose last parameter is a `params` array,
+a method that already declares two or more `CancellationToken` parameters, and a call whose candidate overload takes
+a generic final parameter are all left untouched with no diagnostic. Only the virtual-dispatch case above reports
+`ACT001`; for these, nothing tells you the aspect did nothing.
 
 **Async iterators are not given `[EnumeratorCancellation]`.** The token added to an `async IAsyncEnumerable<T>`
 method is not wired up to the enumerator, so a token passed to `WithCancellation` is unconsumed. This is the one


### PR DESCRIPTION
## Summary

- Makes the unit tests actually run — the project was missing the xUnit VSTest adapter, so `dotnet test` discovered nothing and exited green.
- Adds an overload instead of changing an existing method's signature, so callers are no longer broken.
- Makes the aspect work on nested types, where it was previously a silent no-op.
- Fixes a weaver crash on invocations inside operators, conversion operators and field-like events.
- Fixes name collisions with body locals, and `VisitAnonymousMethodExpression` hardcoding `isStatic: false`.

## Tests never ran (#102)

The project referenced `xunit.assert` but neither `xunit` nor `xunit.runner.visualstudio`. Without the adapter VSTest discovers nothing and **reports success**, so every green run for this aspect was vacuous. `MyClass.cs` carries the regression tests for #7, #8 and #9; none had been guarding anything.

One correction to the issue: I expected the committed `MyClass.t.cs` to be unusable because it looked hand-written. That was wrong — with the adapter added it passed unchanged.

## Overload instead of signature change (#81)

The aspect now keeps the original method and moves the body to a new overload:

```csharp
public Task DoAsync( int v ) => DoAsync( v, default );
public async Task DoAsync( int v, CancellationToken cancellationToken ) { ... }
```

The token parameter deliberately has **no default value** — with one, a call using the original argument list would be ambiguous (CS0121). `BackwardCompatibility` covers this, including generic methods (the forwarder passes the type arguments through) and a caller in a non-annotated type that must still compile against the original signatures.

### Limitation: members involved in virtual dispatch are skipped

This is worth reviewing carefully, because it is a real limit of the approach rather than an implementation shortcut.

A virtual method's signature *is* its dispatch contract, so neither option works:

- **Both members virtual.** A derived class the aspect never sees overrides only the original signature. Calling the token-taking overload then runs the *base* body and silently ignores the override — and that code **compiles**, so nothing warns you.
- **Only the overload virtual.** An existing `override M()` stops compiling with CS0506 — exactly the breaking change #81 asks us to avoid.

Transforming an override is sound only when the base type was transformed too, which cannot be relied on across an assembly boundary. So `virtual`, `abstract`, `override` and explicit interface implementations are now left alone entirely. `VirtualMembers` records this with the reasoning.

The consequence is that virtual members get no cancellation support at all. If that is not acceptable, the alternatives are to report a diagnostic so it is at least not silent, or to transform overrides when the base is visible and annotated — both are design calls I did not want to make unilaterally.

Because the original signature now survives, **implicitly implementing an interface member is no longer a problem** and is transformed again (it was skipped in an earlier commit here, when the signature was still being widened).

## Silent no-op on nested types (#109)

`AnnotateNodesRewriter` and both consumer rewriters returned early for a type without the annotation and therefore never descended into it, so a nested type carrying the attribute itself was never reached. They now always descend, with `RewriterBase` tracking which type is annotated so members are transformed only when their own containing type carries the aspect.

## Weaver crash on non-method members (#104)

`RewriterBase` kept `VisitInvocationExpression` out of non-method members via a hand-written list that omitted `OperatorDeclarationSyntax`, `ConversionOperatorDeclarationSyntax` and `EventFieldDeclarationSyntax`. Fixed on two levels: the missing node types were added, and the argument rewriter now returns early when there is no enclosing method, so an unanticipated member kind is a no-op rather than a crash. Same defect class as #94 and #98.

## Signature and name-collision fixes (#105)

- The name of the added parameter was uniquified only against other parameters, so a body local named `cancellationToken` produced CS0136 *and* the generated call passed that local instead of the token. It is now uniquified against every identifier in the declaration.
- An overload that would duplicate an existing `(…, CancellationToken)` member is still skipped.

## The aspect is now documented as a proof of concept

Reviewing #81 surfaced a broader point: the overload approach preserves existing callers by having the forwarder pass `default`, i.e. `CancellationToken.None`. Those callers keep compiling and gain no cancellation at all, silently. That is characteristic of the aspect as a whole — it decides what to cancel from syntax, with no way to tell an operation that should honour cancellation from one that must run to completion (cleanup, disposal, compensating writes, audit logging).

A related limitation, raised in review: **propagation is not transitive.** The aspect never adds a parameter to a method merely because doing so is what would let a token travel further, so a chain stops at the first method the aspect does not own — even when the cancellable call is one hop away (`TransitivePropagation` pins this). Closing that gap needs a fix-point analysis over the call graph, since adding a parameter to one method changes the answer for its callers; that is generally out of scope for a build-time transformation on cost grounds, and impossible across an assembly boundary. The flip side is that within an annotated type the aspect over-approximates instead: every `async` method gets a token, including ones that never use it.

The package README (which is the NuGet package description) now leads with a proof-of-concept warning and a Limitations section covering all of the above, plus the virtual-dispatch exclusion, the single-compilation scope, and the constructs skipped with no diagnostic. Its example was also stale — it still showed the old signature-widening behaviour.

## Testing

11 tests, up from 0 actually executing. `NonMethodMembers` and `OverridesAndOverloads` were both verified to fail before their fix (`LAMA0041 … NullReferenceException` and `CS0115`/`CS0539` respectively). The virtual-dispatch hole above was found by probing the generated code, not by reasoning — the first implementation of #81 had it, and it compiled cleanly. `AsyncIterator` pins the one limitation the compiler itself warns about (CS8425).

## Issues Fixed

Fixes #81 - Add an overload instead of changing the signature
Fixes #102 - Unit tests never run, missing xunit VSTest adapter
Fixes #104 - Weaver crashes on invocations in operator and field-like event members
Fixes #105 - Parameter appended to overrides, interface implementations and existing overloads
Fixes #109 - Aspect silently ignored on a nested type

— Claude for Gael Fraiteur
